### PR TITLE
Add reducer tests, fix minor reducer bugs

### DIFF
--- a/app/src/api/__tests__/interface.spec.js
+++ b/app/src/api/__tests__/interface.spec.js
@@ -1,4 +1,4 @@
-const { determineComponentToRender: determine } = require('../../app/src/api/interface');
+import { determineComponentToRender as determine } from 'api/interface';
 
 const orgUnitSamples = [
     { displayName: 'OrgUnit1', value: 'v' },
@@ -62,52 +62,52 @@ const samples = {
     },
 };
 
-describe('Interface between App and API', () => {
-    describe('Rendering parameters without options', () => {
-        test('Parameters expecting a string or integer should render as an Input', () => {
+describe('interface between App and API', () => {
+    describe('rendering parameters without options', () => {
+        test('parameters expecting a string or integer should render as an Input', () => {
             expect(determine(samples.string)).toBe('INPUT');
             expect(determine(samples.integer)).toBe('INPUT');
         });
 
-        test('Parameters expecting a boolean should render as a Switch', () => {
+        test('parameters expecting a boolean should render as a Switch', () => {
             expect(determine(samples.boolean)).toBe('TOGGLE');
         });
 
-        test('Parameters expecting a date should render as a Date picker', () => {
+        test('parameters expecting a date should render as a Date picker', () => {
             expect(determine(samples.date)).toBe('DATE');
         });
 
-        test('Parameters expecting a period should render as a Period picker', () => {
+        test('parameters expecting a period should render as a Period picker', () => {
             expect(determine(samples.period)).toBe('PERIOD');
         });
 
-        test('Parameters expecting a list of strings or integers should render as an Input list', () => {
+        test('parameters expecting a list of strings or integers should render as an Input list', () => {
             expect(determine(samples.stringList)).toBe('INPUT_LIST');
             expect(determine(samples.integerList)).toBe('INPUT_LIST');
         });
 
-        test('Parameters expecting a list of periods should render as a Period list', () => {
+        test('parameters expecting a list of periods should render as a Period list', () => {
             expect(determine(samples.periodList)).toBe('PERIOD_LIST');
         });
 
-        test('Parameters expecting a list of anything else, without options, is not supported', () => {
+        test('parameters expecting a list of anything else, without options, is not supported', () => {
             expect(determine(samples.booleanList)).toBe('UNKNOWN');
             expect(determine(samples.orgUnitList)).toBe('UNKNOWN');
         });
     });
 
-    describe('Rendering parameters with external options', () => {
-        test('Parameters including an exclusive list of strings or integers should render as a selection', () => {
+    describe('rendering parameters with external options', () => {
+        test('parameters including an exclusive list of strings or integers should render as a selection', () => {
             expect(determine(samples.stringSetWithOptions)).toBe('SELECTION');
             expect(determine(samples.integerSetWithOptions)).toBe('SELECTION');
         });
 
-        test('Parameters including an inclusive list with suggestions', () => {
+        test('parameters including an inclusive list with suggestions', () => {
             expect(determine(samples.stringListWithOptions)).toBe('SUGGESTION_LIST');
             expect(determine(samples.integerListWithOptions)).toBe('SUGGESTION_LIST');
         });
 
-        test('Parameters including options and expecting only one item', () => {
+        test('parameters including options and expecting only one item', () => {
             expect(determine(samples.orgUnitWithOptions)).toBe('SUGGESTION');
         });
     });

--- a/app/src/components/MessagePanel.jsx
+++ b/app/src/components/MessagePanel.jsx
@@ -38,8 +38,8 @@ class MessagePanel extends Component {
 }
 
 export default connect(state => ({
+    id: state.message.id,
     message: state.message.message,
     type: state.message.type,
-    time: state.message.time,
     persist: state.message.persist,
 }))(MessagePanel);

--- a/app/src/components/jobContent/ActionButtons.jsx
+++ b/app/src/components/jobContent/ActionButtons.jsx
@@ -57,7 +57,9 @@ class ActionButtons extends Component {
         return (
             <div style={styles.buttonPanel}>
                 <Dialog
-                    title={`${i18next.t('are_you_sure_you_want_to_delete')} "${this.props.job.name}"?`}
+                    title={`${i18next.t('are_you_sure_you_want_to_delete')} "${
+                        this.props.job.name
+                    }"?`}
                     actions={deleteDialogActions}
                     open={this.state.deleteDialogOpen}
                     onRequestClose={this.closeDeleteDialog}

--- a/app/src/reducers/__tests__/jobsReducer.spec.js
+++ b/app/src/reducers/__tests__/jobsReducer.spec.js
@@ -1,0 +1,137 @@
+import reducer, { initialState } from 'reducers/jobsReducer';
+import * as actions from 'constants/actions';
+
+describe('jobsReducer', () => {
+    it('should return the initial state', () => {
+        const expectedState = { ...initialState };
+
+        const actualState = reducer(undefined, {});
+        expect(actualState).toEqual(expectedState);
+    });
+
+    it('should handle JOBS_LOAD_SUCCESS', () => {
+        const jobs = [{ displayName: 'testJob' }, { displayName: 'testJob2' }];
+
+        const action = {
+            type: actions.JOBS_LOAD_SUCCESS,
+            payload: { jobs },
+        };
+
+        const expectedState = {
+            ...initialState,
+            all: jobs,
+            loaded: true,
+        };
+
+        const actualState = reducer(initialState, action);
+        expect(actualState).toEqual(expectedState);
+    });
+
+    it('should handle JOB_EDIT', () => {
+        const action = {
+            type: actions.JOB_EDIT,
+            payload: {
+                fieldName: 'name',
+                value: 'New job name',
+            },
+        };
+        const expectedState = {
+            ...initialState,
+            dirty: true,
+            changes: {
+                parameters: null,
+                name: 'New job name',
+            },
+        };
+
+        const actualState = reducer(initialState, action);
+        expect(actualState).toEqual(expectedState);
+    });
+
+    it('should handle JOB_DISCARD', () => {
+        const action = {
+            type: actions.JOB_DISCARD,
+        };
+
+        const dirtyState = {
+            ...initialState,
+            dirty: true,
+            changes: {
+                parameters: {
+                    paramField: 'Param value',
+                },
+                name: 'Name',
+            },
+        };
+
+        const expectedState = {
+            ...initialState,
+            changes: initialState.changes,
+            dirty: false,
+        };
+
+        const actualState = reducer(dirtyState, action);
+        expect(actualState).toEqual(expectedState);
+    });
+
+    it('should handle CONFIGURATION_LOAD_SUCCESS', () => {
+        const jobTypes = ['SEND_SCHEDULED_MESSAGE', 'RUN_ANALYTICS'];
+        const jobStatuses = ['RUNNING, HALTED'];
+        const jobParameters = {
+            SEND_SCHEDULED_MESSAGE: null,
+            RUN_ANALYTICS: null,
+        };
+
+        const action = {
+            type: actions.CONFIGURATION_LOAD_SUCCESS,
+            payload: {
+                configuration: {
+                    loaded: true,
+                    jobTypes,
+                    jobStatuses,
+                    jobParameters,
+                },
+            },
+        };
+
+        const expectedState = {
+            ...initialState,
+            configuration: {
+                loaded: true,
+                types: jobTypes,
+                statuses: jobStatuses,
+                parameters: jobParameters,
+                attributeOptions: {},
+            },
+        };
+
+        const actualState = reducer(initialState, action);
+        expect(actualState).toEqual(expectedState);
+    });
+
+    it('should handle ATTRIBUTE_OPTIONS_LOAD_SUCCESS', () => {
+        const attributeOptions = {
+            RUN_ANALYTICS: {
+                skipTableTypes: ['DATA_VALUE'],
+            },
+        };
+
+        const action = {
+            type: actions.ATTRIBUTE_OPTIONS_LOAD_SUCCESS,
+            payload: {
+                attributeOptions,
+            },
+        };
+
+        const expectedState = {
+            ...initialState,
+            configuration: {
+                ...initialState.configuration,
+                attributeOptions,
+            },
+        };
+
+        const actualState = reducer(initialState, action);
+        expect(actualState).toEqual(expectedState);
+    });
+});

--- a/app/src/reducers/__tests__/messageReducer.spec.js
+++ b/app/src/reducers/__tests__/messageReducer.spec.js
@@ -1,0 +1,84 @@
+import reducer, { initialState } from 'reducers/messageReducer';
+import * as actions from 'constants/actions';
+
+jest.mock('i18next', () => ({
+    t: str => `${str}_translated`,
+}));
+
+describe('messageReducer', () => {
+    it('should return the initial state', () => {
+        const expectedState = { ...initialState };
+
+        const actualState = reducer(undefined, {});
+        expect(actualState).toEqual(expectedState);
+    });
+
+    it('should handle positive messages', () => {
+        const action = {
+            type: actions.JOB_DELETE_SUCCESS,
+        };
+
+        const expectedState = {
+            id: 0,
+            message: 'successfully_deleted_job_translated',
+            type: 'POSITIVE',
+            persist: false,
+        };
+
+        const actualState = reducer(initialState, action);
+        expect(actualState).toEqual(expectedState);
+    });
+
+    describe('should handle errors', () => {
+        const message =
+            'Could not create job because of some obscure bug in the Scheduler back-end';
+        const expectedState = {
+            id: 0,
+            message: `could_not_create_job_translated: ${message}`,
+            type: 'NEGATIVE',
+            persist: false,
+        };
+
+        it('should handle messages with an error message', () => {
+            const action = {
+                type: actions.JOB_POST_ERROR,
+                payload: { error: { message } },
+            };
+
+            const actualState = reducer(initialState, action);
+            expect(actualState).toEqual(expectedState);
+        });
+
+        it('should handle messages with an error report', () => {
+            const action = {
+                type: actions.JOB_POST_ERROR,
+                payload: {
+                    error: {
+                        response: {
+                            errorReports: [{ message }],
+                        },
+                    },
+                },
+            };
+
+            const actualState = reducer(initialState, action);
+            expect(actualState).toEqual(expectedState);
+        });
+    });
+
+    it('should handle NOT_AUTHORIZED', () => {
+        const action = {
+            type: actions.NOT_AUTHORIZED,
+        };
+
+        const expectedState = {
+            id: 0,
+            message: 'not_authorized_message_translated',
+            type: 'NEGATIVE',
+            persist: true,
+        };
+
+        const actualState = reducer(initialState, action);
+        expect(actualState).toEqual(expectedState);
+    });
+});

--- a/app/src/reducers/jobsReducer.js
+++ b/app/src/reducers/jobsReducer.js
@@ -1,6 +1,6 @@
 import * as actions from 'constants/actions';
 
-const initialState = {
+export const initialState = {
     all: [],
     loaded: false,
     dirty: false,

--- a/app/src/reducers/messageReducer.js
+++ b/app/src/reducers/messageReducer.js
@@ -1,16 +1,15 @@
 import * as actions from 'constants/actions';
-import moment from 'moment';
 import i18next from 'i18next';
 
 const NEUTRAL = 'NEUTRAL';
 const POSITIVE = 'POSITIVE';
 const NEGATIVE = 'NEGATIVE';
 
-const initialState = {
+export const initialState = {
+    id: -1,
+    persist: false,
     message: '',
     type: NEUTRAL,
-    persist: false,
-    time: null,
 };
 
 const getErrorMessage = error => {
@@ -21,52 +20,59 @@ const getErrorMessage = error => {
     return error.message;
 };
 
+const increment = number => number + 1;
+
 function messageReducer(state = initialState, action) {
     switch (action.type) {
         case actions.JOB_DELETE_SUCCESS:
             return {
+                id: increment(state.id),
                 message: i18next.t('successfully_deleted_job'),
                 type: POSITIVE,
-                time: moment().format('HH:mm:ss'),
+                persist: false,
             };
 
         case actions.JOB_POST_SUCCESS:
             return {
+                id: increment(state.id),
                 message: i18next.t('successfully_created_job'),
                 type: POSITIVE,
-                time: moment().format('HH:mm:ss'),
+                persist: false,
             };
 
         case actions.JOB_SAVE_SUCCESS:
             return {
+                id: increment(state.id),
                 message: i18next.t('successfully_updated_job'),
                 type: POSITIVE,
-                time: moment().format('HH:mm:ss'),
+                persist: false,
             };
 
         case actions.JOB_POST_ERROR:
             return {
+                id: increment(state.id),
                 message: `${i18next.t('could_not_create_job')}: ${getErrorMessage(
                     action.payload.error,
                 )}`,
                 type: NEGATIVE,
-                time: moment().format('HH:mm:ss'),
+                persist: false,
             };
 
         case actions.JOB_SAVE_ERROR:
             return {
+                id: increment(state.id),
                 message: `${i18next.t('could_not_update_job')}: ${getErrorMessage(
                     action.payload.error,
                 )}`,
                 type: POSITIVE,
-                time: moment().format('HH:mm:ss'),
+                persist: false,
             };
 
         case actions.NOT_AUTHORIZED:
             return {
+                id: increment(state.id),
                 message: i18next.t('not_authorized_message'),
                 type: NEGATIVE,
-                time: moment().format('HH:mm:ss'),
                 persist: true,
             };
 

--- a/package.json
+++ b/package.json
@@ -55,5 +55,15 @@
     "rxjs": "5.5.6",
     "style-loader": "^0.20.1",
     "whatwg-fetch": "^2.0.3"
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "^actions[/](.+)": "<rootDir>/app/src/actions/$1",
+      "^api[/](.+)": "<rootDir>/app/src/api/$1",
+      "^constants[/](.+)": "<rootDir>/app/src/constants/$1",
+      "^components[/](.+)": "<rootDir>/app/src/components/$1",
+      "^reducers[/](.+)": "<rootDir>/app/src/reducers/$1",
+      "^utils[/](.+)": "<rootDir>/app/src/utils/$1"
+    }
   }
 }


### PR DESCRIPTION
* Added tests for job- and message reducers
* Added moduleNameMapper for jest in config
* Added a mock for i18next, might want to move this out of messageReducer test later
* Changed message reducer to use an ID counter instead of timestamps for triggering rerendering
    - Timestamps weren't needed