### PR TITLE
docs(scheduling type): describe behavior for delay & differences to cron

### DIFF
--- a/cypress/integration/Overview_cron_next_execution.feature
+++ b/cypress/integration/Overview_cron_next_execution.feature
@@ -1,0 +1,6 @@
+Feature: On the overview page the user can see delay between delay jobs
+
+    Scenario: At least one cron job already exists
+        Given the overview of jobs is visible
+        And a cron job exists
+        Then the next execution time is displayed

--- a/cypress/integration/Overview_show_delay_time.feature
+++ b/cypress/integration/Overview_show_delay_time.feature
@@ -1,0 +1,6 @@
+Feature: On the overview page the user can see delay between delay jobs
+
+    Scenario: At least one delay job already exists
+        Given the overview of jobs is visible
+        And a delay job exists
+        Then the delay between executions is displayed in seconds

--- a/cypress/integration/Scheduling_types_in_form.feature
+++ b/cypress/integration/Scheduling_types_in_form.feature
@@ -1,0 +1,26 @@
+Feature: The user can choose between cron and delay scheduling type
+
+    Scenario: The user didn't choose a scheduling type yet
+        Given the add-job form is visible
+        And no scheduling type has been selected
+        Then no input fields for either cron or delay are visible
+
+    Scenario: The user adds a new job of scheduling type cron
+        Given the add-job form is visible
+        When a job type without "CONTINUOUS" in its name is selected
+        Then a cron-job pattern can be entered
+
+    Scenario: The user adds a new job of scheduling type delay
+        Given the add-job form is visible
+        When a job type with "CONTINUOUS" in its name is selected
+        Then a delay in seconds can be entered
+
+    Scenario: The user changes an existing cron job to a delay job
+        Given the user opened the edit job form of a cron job
+        When a job type with "CONTINUOUS" in its name is selected
+        Then a delay in seconds can be entered
+
+    Scenario: The user changes an existing delay job to a cron job
+        Given the user opened the edit job form of a delay job
+        When a job type without "CONTINUOUS" in its name is selected
+        Then a cron-job pattern can be entered


### PR DESCRIPTION
Relates to DHIS2-8164

This adds feature files to describe the behavior for delay schedule-types and the introduced differences between delay and cron scheduling-types.