### PR TITLE
fix: use human readable cron label strings

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -154,3 +154,21 @@ msgstr ""
 
 msgid "You are not authorized to use this app"
 msgstr ""
+
+msgid "Custom"
+msgstr ""
+
+msgid "Every hour"
+msgstr ""
+
+msgid "Every day midnight"
+msgstr ""
+
+msgid "Every day at three am"
+msgstr ""
+
+msgid "Every weekday at noon"
+msgstr ""
+
+msgid "Every week"
+msgstr ""

--- a/src/constants/cronExpressions.js
+++ b/src/constants/cronExpressions.js
@@ -1,10 +1,10 @@
 const cronExpressions = [
-    { text: 'CUSTOM', value: '' },
-    { text: 'EVERY_HOUR', value: '0 0 * ? * *' },
-    { text: 'EVERY_DAY_MIDNIGHT', value: '0 0 1 ? * *' },
-    { text: 'EVERY_DAY_THREE_AM', value: '0 0 3 ? * *' },
-    { text: 'EVERY_WEEKDAY_NOON', value: '0 0 12 ? * MON-FRI' },
-    { text: 'EVERY_WEEK', value: '0 0 3 ? * MON' },
+    { text: 'Custom', value: '' },
+    { text: 'Every hour', value: '0 0 * ? * *' },
+    { text: 'Every day midnight', value: '0 0 1 ? * *' },
+    { text: 'Every day at three am', value: '0 0 3 ? * *' },
+    { text: 'Every weekday at noon', value: '0 0 12 ? * MON-FRI' },
+    { text: 'Every week', value: '0 0 3 ? * MON' },
 ];
 
 export default cronExpressions;


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-8301

I was curious what was going wrong here, so I quickly created this. Tbh. I'm not sure how this worked in the past. There haven't been any translations for these labels for what I could find, but I suspect I'm overlooking sth. If we can find the core issue that'd be best, otherwise this at least patches the reported bug.

(I don't see why we would use SCREAMING_SNAKE_CASE or macro case for the cron preset labels. It's not referenced anywhere else, so might as well make that human friendly)

Might be that we have to update the translations in transifex btw, not here, I'm not sure atm. (edit: we don't, transifex is not enabled yet for this app).