### PR TITLE
refactor: fix next run time display

### DIFF
--- a/src/pages/JobList/JobListTableItem.js
+++ b/src/pages/JobList/JobListTableItem.js
@@ -1,24 +1,11 @@
 import React from 'react'
-import moment from 'moment'
 import { bool, shape, string } from 'prop-types'
 import cronstrue from 'cronstrue'
 import { TableRow, TableCell } from '@dhis2/ui-core'
 import { ToggleJobSwitch } from '../../components/Switches'
 import JobListActions from './JobListActions'
 import JobStatus from './JobStatus'
-
-/**
- * The use of moment below is to display in how much time the task
- * will run again. This should always be in the future (so, 'in xxx
- * hours', etc). At the moment though, we sometimes receive timestamps
- * that are in the past, which will cause the displayed relative time
- * to refer to the past as well ('xxx hours ago', etc.).
- *
- * Besides that, according to the moment docs you would expect toNow()
- * to be the correct method, as all those examples are describing future
- * events. But using fromNow() actually results in future relative time,
- * so that could be a mistake in the moment docs.
- */
+import JobNextRun from './JobNextRun'
 
 const JobListTableItem = ({
     job: {
@@ -35,7 +22,12 @@ const JobListTableItem = ({
         <TableCell>{displayName}</TableCell>
         <TableCell>{jobType}</TableCell>
         <TableCell>{cronstrue.toString(cronExpression)}</TableCell>
-        <TableCell>{moment(nextExecutionTime).fromNow()}</TableCell>
+        <TableCell>
+            <JobNextRun
+                nextExecutionTime={nextExecutionTime}
+                enabled={enabled}
+            />
+        </TableCell>
         <TableCell>
             <JobStatus status={jobStatus} />
         </TableCell>

--- a/src/pages/JobList/JobListTableItem.test.js
+++ b/src/pages/JobList/JobListTableItem.test.js
@@ -2,9 +2,6 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import JobListTableItem from './JobListTableItem'
 
-// Return a fixed relative time when fromNow is called
-jest.mock('moment', () => () => ({ fromNow: () => 'in 10 days' }))
-
 describe('<JobListTableItem>', () => {
     it('renders correctly', () => {
         const job = {

--- a/src/pages/JobList/JobNextRun.js
+++ b/src/pages/JobList/JobNextRun.js
@@ -1,0 +1,37 @@
+import moment from 'moment'
+import { string, bool } from 'prop-types'
+
+const JobNextRun = ({ nextExecutionTime, enabled }) => {
+    if (!enabled) {
+        return '-'
+    }
+
+    const now = moment(Date.now())
+
+    /**
+     * The recommendation is to run dhis2 on a server set to UTC time.
+     * In that case this timestamp is also UTC. If those recommendations
+     * weren't followed the time could be off, but there's nothing
+     * we can do to detect that.
+     */
+    const nextRun = moment.utc(nextExecutionTime)
+    const nextRunIsInPast = nextRun.isSameOrBefore(now, 'minute')
+
+    /**
+     * If the time is in the past, that could mean that the task is running,
+     * and the nextExecutionTime hasn't been updated yet.
+     */
+
+    if (nextRunIsInPast) {
+        return 'Not scheduled'
+    }
+
+    return now.to(nextRun)
+}
+
+JobNextRun.propTypes = {
+    enabled: bool.isRequired,
+    nextExecutionTime: string.isRequired,
+}
+
+export default JobNextRun

--- a/src/pages/JobList/JobNextRun.test.js
+++ b/src/pages/JobList/JobNextRun.test.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import JobNextRun from './JobNextRun'
+
+// Z is the zone designator for the zero UTC offset
+const now = new Date('2010-10-10T10:10:10.000Z').valueOf()
+
+// The server does not specify a timezone, but is assumed to provide UTC
+const past = '2009-10-10T10:10:10.000'
+const future = '2011-10-10T10:10:10.000'
+
+describe('<JobNextRun>', () => {
+    it('returns the next run time for an enabled job and a future execution time', () => {
+        jest.spyOn(global.Date, 'now').mockImplementationOnce(() => now)
+
+        const wrapper = shallow(
+            <JobNextRun nextExecutionTime={future} enabled={true} />
+        )
+
+        expect(wrapper).toMatchSnapshot()
+    })
+
+    it('returns fallback message for an enabled job and a past execution time', () => {
+        jest.spyOn(global.Date, 'now').mockImplementationOnce(() => now)
+
+        const wrapper = shallow(
+            <JobNextRun nextExecutionTime={past} enabled={true} />
+        )
+
+        expect(wrapper).toMatchSnapshot()
+    })
+
+    it('returns fallback message for a disabled job', () => {
+        jest.spyOn(global.Date, 'now').mockImplementationOnce(() => now)
+
+        const wrapper = shallow(
+            <JobNextRun nextExecutionTime={''} enabled={false} />
+        )
+
+        expect(wrapper).toMatchSnapshot()
+    })
+})

--- a/src/pages/JobList/__snapshots__/JobListTableItem.test.js.snap
+++ b/src/pages/JobList/__snapshots__/JobListTableItem.test.js.snap
@@ -22,7 +22,10 @@ exports[`<JobListTableItem> renders correctly 1`] = `
   <TableCell
     dataTest="dhis2-uicore-tablecell"
   >
-    in 10 days
+    <JobNextRun
+      enabled={true}
+      nextExecutionTime="2100-10-10T14:48:00"
+    />
   </TableCell>
   <TableCell
     dataTest="dhis2-uicore-tablecell"

--- a/src/pages/JobList/__snapshots__/JobNextRun.test.js.snap
+++ b/src/pages/JobList/__snapshots__/JobNextRun.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<JobNextRun> returns fallback message for a disabled job 1`] = `"-"`;
+
+exports[`<JobNextRun> returns fallback message for an enabled job and a past execution time 1`] = `"Not scheduled"`;
+
+exports[`<JobNextRun> returns the next run time for an enabled job and a future execution time 1`] = `"in a year"`;


### PR DESCRIPTION
Small inbetween fix following up on a todo point from #38. I thought that there was a bug in the jobConfigurations endpoint, as it seemed to be returning timestamps in the past.

But after talking to Morten about it I understand that this endpoint can be assumed to return UTC time (see slack [here](https://dhis2.slack.com/archives/C1XNHEY0L/p1585128053002800)). So I'm now parsing it as UTC and have abstracted it to a separate component and added some tests.