### PR TITLE
fix: import upstream scheduling type changes

### DIFF
--- a/src/components/FormFields/DelayField.js
+++ b/src/components/FormFields/DelayField.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import {
+    Field,
+    Input,
+    composeValidators,
+    hasValue,
+    integer,
+    createNumberRange,
+} from '@dhis2/ui-forms'
+
+const LOWER_BOUND = 1
+const UPPER_BOUND = 86400
+
+// The key under which this field will be sent to the backend
+export const FIELD_NAME = 'delay'
+export const VALIDATOR = composeValidators(
+    integer,
+    hasValue,
+    createNumberRange(LOWER_BOUND, UPPER_BOUND)
+)
+
+const DelayField = () => (
+    <Field
+        component={Input}
+        name={FIELD_NAME}
+        validate={VALIDATOR}
+        label="Delay"
+        type="number"
+        helpText={`Delay in seconds (${LOWER_BOUND} - ${UPPER_BOUND})`}
+        required
+    />
+)
+
+export default DelayField

--- a/src/components/FormFields/JobTypeField.js
+++ b/src/components/FormFields/JobTypeField.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Field, SingleSelect } from '@dhis2/ui-forms'
 import { SingleSelectField } from '@dhis2/ui-core'
 import { requiredSingleSelectOption } from '../../services/validators'
-import { useGetJobTypes, selectors } from '../../hooks/job-types'
+import { useGetJobTypes } from '../../hooks/job-types'
 
 // The key under which this field will be sent to the backend
 export const FIELD_NAME = 'jobType'
@@ -19,9 +19,9 @@ const JobTypeField = () => {
         return <SingleSelectField error helpText={error.message} />
     }
 
-    const options = selectors.getJobTypes(data).map(type => ({
-        value: type,
-        label: type,
+    const options = data.map(({ jobType, name }) => ({
+        value: jobType,
+        label: name,
     }))
 
     return (
@@ -30,6 +30,8 @@ const JobTypeField = () => {
             validate={VALIDATOR}
             component={SingleSelect}
             options={options}
+            label="Job type"
+            required
         />
     )
 }

--- a/src/components/FormFields/ParameterFields.js
+++ b/src/components/FormFields/ParameterFields.js
@@ -15,10 +15,6 @@ const FIELD_NAME = 'jobParameters'
 const ParameterFields = ({ jobType }) => {
     const { loading, error, data } = useGetJobTypes()
 
-    if (!jobType) {
-        return null
-    }
-
     if (loading) {
         return <span>Loading</span>
     }
@@ -35,6 +31,7 @@ const ParameterFields = ({ jobType }) => {
             key: name,
             name: `${FIELD_NAME}.${name}`,
         }
+        const endpoint = selectors.getParameterEndpoint(relativeApiEndpoint)
 
         switch (klass) {
             case 'java.lang.String':
@@ -55,7 +52,7 @@ const ParameterFields = ({ jobType }) => {
                 return (
                     <UnlabeledOptionsField
                         {...defaultProps}
-                        endpoint={relativeApiEndpoint}
+                        endpoint={endpoint}
                     />
                 )
             case 'java.util.List':
@@ -63,7 +60,7 @@ const ParameterFields = ({ jobType }) => {
                     <LabeledOptionsField
                         {...defaultProps}
                         parameterName={name}
-                        endpoint={relativeApiEndpoint}
+                        endpoint={endpoint}
                     />
                 )
             default:

--- a/src/components/FormFields/ScheduleField.js
+++ b/src/components/FormFields/ScheduleField.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { string } from 'prop-types'
+import { useGetJobTypes, selectors } from '../../hooks/job-types'
+import CronField from './CronField'
+import DelayField from './DelayField'
+
+const ScheduleField = ({ jobType }) => {
+    const { loading, error, data } = useGetJobTypes()
+
+    if (loading) {
+        return <span>Loading job types</span>
+    }
+
+    if (error) {
+        return <span>{error.message}</span>
+    }
+
+    const currentJob = selectors.getJobTypeObject(data, jobType)
+    const schedulingType = currentJob.schedulingType
+
+    switch (schedulingType) {
+        case 'CRON':
+            return <CronField />
+        case 'FIXED_DELAY':
+            return <DelayField />
+        default:
+            // Unrecognised scheduling type
+            return null
+    }
+}
+
+ScheduleField.propTypes = {
+    jobType: string.isRequired,
+}
+
+export default ScheduleField

--- a/src/components/FormFields/index.js
+++ b/src/components/FormFields/index.js
@@ -2,15 +2,13 @@ import JobNameField, {
     FIELD_NAME as JOB_NAME,
     VALIDATOR as JOB_NAME_VALIDATOR,
 } from './JobNameField'
-import CronField, {
-    FIELD_NAME as CRON,
-    VALIDATOR as CRON_VALIDATOR,
-} from './CronField'
+import { FIELD_NAME as CRON, VALIDATOR as CRON_VALIDATOR } from './CronField'
 import JobTypeField, {
     FIELD_NAME as JOB_TYPE,
     VALIDATOR as JOB_TYPE_VALIDATOR,
 } from './JobTypeField'
 import ParameterFields from './ParameterFields'
+import ScheduleField from './ScheduleField'
 
 const fieldNames = {
     JOB_NAME,
@@ -26,7 +24,7 @@ const validators = {
 
 export {
     JobNameField,
-    CronField,
+    ScheduleField,
     JobTypeField,
     ParameterFields,
     fieldNames,

--- a/src/components/Forms/JobForm.js
+++ b/src/components/Forms/JobForm.js
@@ -5,7 +5,7 @@ import { Button } from '@dhis2/ui-core'
 import { InlineError } from '../Errors'
 import { DiscardFormButton } from '../Buttons'
 import {
-    CronField,
+    ScheduleField,
     JobNameField,
     JobTypeField,
     ParameterFields,
@@ -19,6 +19,7 @@ const JobForm = ({
     values,
     setIsPristine,
 }) => {
+    // Check if there's currently a selected job type
     const hasJobType =
         values[fieldNames.JOB_TYPE] && 'value' in values[fieldNames.JOB_TYPE]
     const jobType = hasJobType ? values[fieldNames.JOB_TYPE].value : ''
@@ -30,9 +31,9 @@ const JobForm = ({
                 onChange={({ pristine }) => setIsPristine(pristine)}
             />
             <JobNameField />
-            <CronField />
             <JobTypeField />
-            <ParameterFields jobType={jobType} />
+            {jobType && <ScheduleField jobType={jobType} />}
+            {jobType && <ParameterFields jobType={jobType} />}
             <div>
                 {!!submitError.message && (
                     <InlineError

--- a/src/hooks/job-types/use-get-job-types.js
+++ b/src/hooks/job-types/use-get-job-types.js
@@ -2,15 +2,15 @@ import { useDataQuery } from '@dhis2/app-runtime'
 
 const query = {
     jobTypes: {
-        resource: 'jobConfigurations/jobTypesExtended',
+        resource: 'jobConfigurations/jobTypes',
     },
 }
 
 const useGetJobTypes = () => {
     const { loading, error, data, refetch } = useDataQuery(query)
 
-    if (data && data.jobTypes) {
-        return { loading, error, refetch, data: data.jobTypes }
+    if (data && data.jobTypes && data.jobTypes.jobTypes) {
+        return { loading, error, refetch, data: data.jobTypes.jobTypes }
     }
 
     return { loading, error, refetch, data }
@@ -22,15 +22,11 @@ export default useGetJobTypes
  * Selectors
  */
 
-export const getJobTypes = jobTypes => {
-    return Object.keys(jobTypes)
-}
-
 /**
- * Returns the parameter and cleans up the endpoint for use with the data engine
+ * Cleans up the endpoint for use with the data engine
  */
 
-const formatEndpoint = endpoint => {
+export const getParameterEndpoint = endpoint => {
     if (!endpoint || !endpoint.startsWith('/api/')) {
         return endpoint
     }
@@ -39,14 +35,12 @@ const formatEndpoint = endpoint => {
     return endpoint.slice(5)
 }
 
-export const getJobTypeParameter = (jobTypes, jobType, parameterName) => {
-    const job = jobTypes[jobType]
-    const parameter = job[parameterName]
+/**
+ * Find a jobType object by the jobType string
+ */
 
-    return {
-        ...parameter,
-        relativeApiEndpoint: formatEndpoint(parameter.relativeApiEndpoint),
-    }
+export const getJobTypeObject = (jobTypes, jobType) => {
+    return jobTypes.find(job => job.jobType === jobType)
 }
 
 /**
@@ -54,9 +48,12 @@ export const getJobTypeParameter = (jobTypes, jobType, parameterName) => {
  */
 
 export const getJobTypeParameters = (jobTypes, jobType) => {
-    const parameterNames = Object.keys(jobTypes[jobType])
+    const selectedJobType = getJobTypeObject(jobTypes, jobType)
+    const hasParameters = 'jobParameters' in selectedJobType
 
-    return parameterNames.map(parameterName =>
-        getJobTypeParameter(jobTypes, jobType, parameterName)
-    )
+    if (!hasParameters) {
+        return []
+    }
+
+    return selectedJobType.jobParameters
 }

--- a/src/pages/JobList/JobListTable.test.js
+++ b/src/pages/JobList/JobListTable.test.js
@@ -4,16 +4,27 @@ import JobListTable from './JobListTable'
 
 describe('<JobListTable>', () => {
     it('renders correctly when there are jobs', () => {
-        const jobIds = ['1']
+        const jobIds = ['1', '2']
         const jobEntities = {
             1: {
-                id: '1',
-                displayName: '',
-                jobType: '',
-                cronExpression: '',
-                jobStatus: '',
-                nextExecutionTime: '',
+                cronExpression: '0 0 * ? * *',
+                displayName: 'Name',
                 enabled: true,
+                id: '1',
+                jobStatus: 'ENABLED',
+                jobType: 'Type',
+                nextExecutionTime: '2100-10-10T14:48:00',
+                schedulingType: 'CRON',
+            },
+            2: {
+                delay: 6000,
+                displayName: 'Name',
+                enabled: true,
+                id: '2',
+                jobStatus: 'ENABLED',
+                jobType: 'Type',
+                nextExecutionTime: '',
+                schedulingType: 'FIXED_DELAY',
             },
         }
         const wrapper = shallow(

--- a/src/pages/JobList/JobListTableItem.js
+++ b/src/pages/JobList/JobListTableItem.js
@@ -1,11 +1,11 @@
 import React from 'react'
-import { bool, shape, string } from 'prop-types'
-import cronstrue from 'cronstrue'
+import { bool, shape, string, number } from 'prop-types'
 import { TableRow, TableCell } from '@dhis2/ui-core'
 import { ToggleJobSwitch } from '../../components/Switches'
 import JobListActions from './JobListActions'
 import JobStatus from './JobStatus'
 import JobNextRun from './JobNextRun'
+import JobSchedule from './JobSchedule'
 
 const JobListTableItem = ({
     job: {
@@ -13,15 +13,23 @@ const JobListTableItem = ({
         displayName,
         jobType,
         cronExpression,
+        delay,
         jobStatus,
         nextExecutionTime,
+        schedulingType,
         enabled,
     },
 }) => (
     <TableRow>
         <TableCell>{displayName}</TableCell>
         <TableCell>{jobType}</TableCell>
-        <TableCell>{cronstrue.toString(cronExpression)}</TableCell>
+        <TableCell>
+            <JobSchedule
+                cronExpression={cronExpression}
+                delay={delay}
+                schedulingType={schedulingType}
+            />
+        </TableCell>
         <TableCell>
             <JobNextRun
                 nextExecutionTime={nextExecutionTime}
@@ -42,13 +50,15 @@ const JobListTableItem = ({
 
 JobListTableItem.propTypes = {
     job: shape({
-        id: string.isRequired,
         displayName: string.isRequired,
-        jobType: string.isRequired,
-        cronExpression: string.isRequired,
-        nextExecutionTime: string.isRequired,
-        jobStatus: string.isRequired,
         enabled: bool.isRequired,
+        id: string.isRequired,
+        jobStatus: string.isRequired,
+        jobType: string.isRequired,
+        schedulingType: string.isRequired,
+        cronExpression: string,
+        delay: number,
+        nextExecutionTime: string,
     }).isRequired,
 }
 

--- a/src/pages/JobList/JobListTableItem.test.js
+++ b/src/pages/JobList/JobListTableItem.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme'
 import JobListTableItem from './JobListTableItem'
 
 describe('<JobListTableItem>', () => {
-    it('renders correctly', () => {
+    it('renders cron jobs correctly', () => {
         const job = {
             id: '1',
             displayName: 'Name',
@@ -12,6 +12,23 @@ describe('<JobListTableItem>', () => {
             jobStatus: 'ENABLED',
             nextExecutionTime: '2100-10-10T14:48:00',
             enabled: true,
+            schedulingType: 'CRON',
+        }
+        const wrapper = shallow(<JobListTableItem job={job} />)
+
+        expect(wrapper).toMatchSnapshot()
+    })
+
+    it('renders fixed delay jobs correctly', () => {
+        const job = {
+            id: '1',
+            displayName: 'Name',
+            jobType: 'Type',
+            jobStatus: 'ENABLED',
+            nextExecutionTime: '',
+            enabled: true,
+            schedulingType: 'FIXED_DELAY',
+            delay: 6000,
         }
         const wrapper = shallow(<JobListTableItem job={job} />)
 

--- a/src/pages/JobList/JobNextRun.js
+++ b/src/pages/JobList/JobNextRun.js
@@ -2,7 +2,7 @@ import moment from 'moment'
 import { string, bool } from 'prop-types'
 
 const JobNextRun = ({ nextExecutionTime, enabled }) => {
-    if (!enabled) {
+    if (!enabled || !nextExecutionTime) {
         return '-'
     }
 
@@ -31,7 +31,7 @@ const JobNextRun = ({ nextExecutionTime, enabled }) => {
 
 JobNextRun.propTypes = {
     enabled: bool.isRequired,
-    nextExecutionTime: string.isRequired,
+    nextExecutionTime: string,
 }
 
 export default JobNextRun

--- a/src/pages/JobList/JobSchedule.js
+++ b/src/pages/JobList/JobSchedule.js
@@ -1,0 +1,22 @@
+import cronstrue from 'cronstrue'
+import { string, number } from 'prop-types'
+
+const JobSchedule = ({ cronExpression, schedulingType, delay }) => {
+    switch (schedulingType) {
+        case 'CRON':
+            return cronstrue.toString(cronExpression)
+        case 'FIXED_DELAY':
+            return delay + ' seconds after last run'
+        default:
+            // Unrecognised or invalid type
+            return '-'
+    }
+}
+
+JobSchedule.propTypes = {
+    schedulingType: string.isRequired,
+    cronExpression: string,
+    delay: number,
+}
+
+export default JobSchedule

--- a/src/pages/JobList/__snapshots__/JobListTable.test.js.snap
+++ b/src/pages/JobList/__snapshots__/JobListTable.test.js.snap
@@ -51,16 +51,32 @@ exports[`<JobListTable> renders correctly when there are jobs 1`] = `
     <JobListTableItem
       job={
         Object {
-          "cronExpression": "",
-          "displayName": "",
+          "cronExpression": "0 0 * ? * *",
+          "displayName": "Name",
           "enabled": true,
           "id": "1",
-          "jobStatus": "",
-          "jobType": "",
-          "nextExecutionTime": "",
+          "jobStatus": "ENABLED",
+          "jobType": "Type",
+          "nextExecutionTime": "2100-10-10T14:48:00",
+          "schedulingType": "CRON",
         }
       }
       key="1"
+    />
+    <JobListTableItem
+      job={
+        Object {
+          "delay": 6000,
+          "displayName": "Name",
+          "enabled": true,
+          "id": "2",
+          "jobStatus": "ENABLED",
+          "jobType": "Type",
+          "nextExecutionTime": "",
+          "schedulingType": "FIXED_DELAY",
+        }
+      }
+      key="2"
     />
   </TableBody>
 </Table>

--- a/src/pages/JobList/__snapshots__/JobListTableItem.test.js.snap
+++ b/src/pages/JobList/__snapshots__/JobListTableItem.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<JobListTableItem> renders correctly 1`] = `
+exports[`<JobListTableItem> renders cron jobs correctly 1`] = `
 <TableRow
   dataTest="dhis2-uicore-tablerow"
 >
@@ -17,7 +17,10 @@ exports[`<JobListTableItem> renders correctly 1`] = `
   <TableCell
     dataTest="dhis2-uicore-tablecell"
   >
-    Every hour
+    <JobSchedule
+      cronExpression="0 0 * ? * *"
+      schedulingType="CRON"
+    />
   </TableCell>
   <TableCell
     dataTest="dhis2-uicore-tablecell"
@@ -25,6 +28,61 @@ exports[`<JobListTableItem> renders correctly 1`] = `
     <JobNextRun
       enabled={true}
       nextExecutionTime="2100-10-10T14:48:00"
+    />
+  </TableCell>
+  <TableCell
+    dataTest="dhis2-uicore-tablecell"
+  >
+    <JobStatus
+      status="ENABLED"
+    />
+  </TableCell>
+  <TableCell
+    dataTest="dhis2-uicore-tablecell"
+  >
+    <ToggleJobSwitch
+      checked={true}
+      id="1"
+    />
+  </TableCell>
+  <TableCell
+    dataTest="dhis2-uicore-tablecell"
+  >
+    <JobListActions
+      id="1"
+    />
+  </TableCell>
+</TableRow>
+`;
+
+exports[`<JobListTableItem> renders fixed delay jobs correctly 1`] = `
+<TableRow
+  dataTest="dhis2-uicore-tablerow"
+>
+  <TableCell
+    dataTest="dhis2-uicore-tablecell"
+  >
+    Name
+  </TableCell>
+  <TableCell
+    dataTest="dhis2-uicore-tablecell"
+  >
+    Type
+  </TableCell>
+  <TableCell
+    dataTest="dhis2-uicore-tablecell"
+  >
+    <JobSchedule
+      delay={6000}
+      schedulingType="FIXED_DELAY"
+    />
+  </TableCell>
+  <TableCell
+    dataTest="dhis2-uicore-tablecell"
+  >
+    <JobNextRun
+      enabled={true}
+      nextExecutionTime=""
     />
   </TableCell>
   <TableCell


### PR DESCRIPTION
This pulls in the latest changes from master, specifically:

* https://github.com/dhis2/scheduler-app/commit/bb3a908c2f7bc75a9587376808b7fba236129ddc
* https://github.com/dhis2/scheduler-app/commit/e14ccd8541cbee6769dbd645cd9b9a49fcfac9e5

There were changes to add a new scheduling type; `FIXED_DELAY`. The design for the refactor was made before these job types were introduced, so until we have a new design, this will just allow the app to work with the new job types in the same manner as master.

1. Fixed delay jobs do not get a nextExecutionTime at the moment. We could calculate that client side, but since the scheduling logic should already be present on the backend, it's probably best to retrieve it from there to prevent divergence. Once addressed on the backend the app will display the next execution time for fixed delay jobs as well.
2. The schedule for delay jobs is simply displayed as `{delay} seconds after last run`. Eventually this should be i18n'd and displayed as a more human friendly duration, but here I'd like to await an updated design as well.

After this I'll update the styling for the add job form to match the design, so I've left the (lack of) styling as is for this PR. Same goes for i18n and form validation on submit, which I'm planning on adding separately as well.