### PR TITLE
feat: add translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@
 .env.test.local
 .env.production.local
 
+# package manager files
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# generated
+src/locales

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -1,0 +1,243 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: i18next-conv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"POT-Creation-Date: 2020-04-01T08:43:39.898Z\n"
+"PO-Revision-Date: 2020-04-01T08:43:39.898Z\n"
+
+msgid "Checking permissions"
+msgstr ""
+
+msgid "You are not authorized"
+msgstr ""
+
+msgid "Choose from preset times"
+msgstr ""
+
+msgid "Delete"
+msgstr ""
+
+msgid "Something went wrong"
+msgstr ""
+
+msgid "The error message was"
+msgstr ""
+
+msgid "CRON Expression"
+msgstr ""
+
+msgid "Delay"
+msgstr ""
+
+msgid "Delay in seconds ({{ lowerBound }} - {{ upperBound }})"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "Loading job types"
+msgstr ""
+
+msgid "Job type"
+msgstr ""
+
+msgid "No options available"
+msgstr ""
+
+msgid "Loading"
+msgstr ""
+
+msgid "Save job"
+msgstr ""
+
+msgid "Cancel"
+msgstr ""
+
+msgid "Every hour"
+msgstr ""
+
+msgid "Every day at midnight"
+msgstr ""
+
+msgid "Every day at 3 am"
+msgstr ""
+
+msgid "Every day at noon"
+msgstr ""
+
+msgid "Every week"
+msgstr ""
+
+msgid "Choose a preset time/interval"
+msgstr ""
+
+msgid "Insert preset"
+msgstr ""
+
+msgid "Are you sure you want to delete this job?"
+msgstr ""
+
+msgid "Are you sure you want to discard this form?"
+msgstr ""
+
+msgid "Discard"
+msgstr ""
+
+msgid "Are you sure you want to run this job?"
+msgstr ""
+
+msgid "Run"
+msgstr ""
+
+msgid "Back to all jobs"
+msgstr ""
+
+msgid "New Job"
+msgstr ""
+
+msgid "Configuration"
+msgstr ""
+
+msgid "About job configuration"
+msgstr ""
+
+msgid "Edit"
+msgstr ""
+
+msgid "Scheduled jobs"
+msgstr ""
+
+msgid "Filter jobs"
+msgstr ""
+
+msgid "Show system jobs"
+msgstr ""
+
+msgid "New job"
+msgstr ""
+
+msgid "Actions"
+msgstr ""
+
+msgid "Loading jobs"
+msgstr ""
+
+msgid "Job name"
+msgstr ""
+
+msgid "Type"
+msgstr ""
+
+msgid "Schedule"
+msgstr ""
+
+msgid "Next run"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "On/off"
+msgstr ""
+
+msgid "No jobs to display"
+msgstr ""
+
+msgid "Not scheduled"
+msgstr ""
+
+msgid "{{ delay }} seconds after last run"
+msgstr ""
+
+msgid "Stopped"
+msgstr ""
+
+msgid "Disabled"
+msgstr ""
+
+msgid "Running"
+msgstr ""
+
+msgid "Not started"
+msgstr ""
+
+msgid "Scheduled"
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Done"
+msgstr ""
+
+msgid "Run manually"
+msgstr ""
+
+msgid "Analytics table"
+msgstr ""
+
+msgid "Continuous analytics table"
+msgstr ""
+
+msgid "Credentials expiry alert"
+msgstr ""
+
+msgid "Dataset notification"
+msgstr ""
+
+msgid "Data statistics"
+msgstr ""
+
+msgid "Data integrity"
+msgstr ""
+
+msgid "Data sync"
+msgstr ""
+
+msgid "Event programs data sync"
+msgstr ""
+
+msgid "File resource clean up"
+msgstr ""
+
+msgid "Meta data sync"
+msgstr ""
+
+msgid "Monitoring"
+msgstr ""
+
+msgid "Predictor"
+msgstr ""
+
+msgid "Program notifications"
+msgstr ""
+
+msgid "Push analysis"
+msgstr ""
+
+msgid "Remove expired reserved values"
+msgstr ""
+
+msgid "Resource table"
+msgstr ""
+
+msgid "Send scheduled message"
+msgstr ""
+
+msgid "Tracker programs data sync"
+msgstr ""
+
+msgid "Validation result notification"
+msgstr ""
+
+msgid "A CRON expression is required"
+msgstr ""
+
+msgid "Please enter a valid CRON expression"
+msgstr ""
+
+msgid "Please select an option"
+msgstr ""

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     },
     "dependencies": {
         "@dhis2/app-runtime": "^2.1.0",
+        "@dhis2/d2-i18n": "^1.0.6",
         "@dhis2/ui-core": "^4.14.0",
         "@dhis2/ui-forms": "^1.0.1",
         "@dhis2/ui-widgets": "^1.0.6",
@@ -44,7 +45,8 @@
         "stylelint-no-unsupported-browser-features": "^3.0.2"
     },
     "resolutions": {
-        "@dhis2/ui-core": "^4.14.0"
+        "@dhis2/ui-core": "^4.14.0",
+        "@dhis2/d2-i18n": "^1.0.6"
     },
     "husky": {
         "hooks": {

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { CssReset, CssVariables } from '@dhis2/ui-core'
+import { CssVariables } from '@dhis2/ui-core'
 import { Routes } from '../Routes'
 import { PageWrapper } from '../PageWrapper'
 import { AuthWall } from '../AuthWall'
@@ -7,7 +7,6 @@ import './App.css'
 
 const App = () => (
     <React.Fragment>
-        <CssReset />
         <CssVariables spacers />
         <PageWrapper>
             <AuthWall>

--- a/src/components/App/__snapshots__/App.test.js.snap
+++ b/src/components/App/__snapshots__/App.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`<App> renders correctly 1`] = `
 <Fragment>
-  <CssReset />
   <CssVariables
     colors={false}
     elevations={false}

--- a/src/components/AuthWall/AuthWall.js
+++ b/src/components/AuthWall/AuthWall.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { node } from 'prop-types'
 import { CircularLoader } from '@dhis2/ui-core'
+import i18n from '@dhis2/d2-i18n'
 import { useGetMe, selectors } from '../../hooks/me'
 import { AbsoluteCenter } from '../AbsoluteCenter'
 import { FullscreenError } from '../Errors'
@@ -12,7 +13,7 @@ const AuthWall = ({ children }) => {
         return (
             <AbsoluteCenter vertical>
                 <CircularLoader />
-                Checking permissions
+                {i18n.t('Checking permissions')}
             </AbsoluteCenter>
         )
     }
@@ -24,7 +25,7 @@ const AuthWall = ({ children }) => {
     const isAuthorized = selectors.getAuthorized(data)
 
     if (!isAuthorized) {
-        return <FullscreenError message={'You are not authorized'} />
+        return <FullscreenError message={i18n.t('You are not authorized')} />
     }
 
     return <React.Fragment>{children}</React.Fragment>

--- a/src/components/Buttons/CronPresetButton.js
+++ b/src/components/Buttons/CronPresetButton.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { func } from 'prop-types'
 import { Button } from '@dhis2/ui-core'
+import i18n from '@dhis2/d2-i18n'
 import { CronPresetModal } from '../Modal'
 
 const CronPresetButton = ({ setCron }) => {
@@ -9,7 +10,7 @@ const CronPresetButton = ({ setCron }) => {
     return (
         <React.Fragment>
             <Button primary onClick={() => setShowModal(true)}>
-                Choose from preset times
+                {i18n.t('Choose from preset times')}
             </Button>
             {showModal && (
                 <CronPresetModal

--- a/src/components/Buttons/DeleteJobButton.js
+++ b/src/components/Buttons/DeleteJobButton.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { string } from 'prop-types'
 import { Button } from '@dhis2/ui-core'
+import i18n from '@dhis2/d2-i18n'
 import { DeleteJobModal } from '../Modal'
 
 const DeleteJobButton = ({ id }) => {
@@ -9,7 +10,7 @@ const DeleteJobButton = ({ id }) => {
     return (
         <React.Fragment>
             <Button destructive onClick={() => setShowModal(true)}>
-                Delete
+                {i18n.t('Delete')}
             </Button>
             {showModal && (
                 <DeleteJobModal id={id} hideModal={() => setShowModal(false)} />

--- a/src/components/Cron/HumanReadableCron.js
+++ b/src/components/Cron/HumanReadableCron.js
@@ -1,0 +1,26 @@
+import { string } from 'prop-types'
+import cronstrue from 'cronstrue/i18n'
+import { useGetUserSettings, selectors } from '../../hooks/user-settings'
+
+const HumanReadableCron = ({ cronExpression }) => {
+    const { loading, error, data } = useGetUserSettings()
+
+    if (loading) {
+        return null
+    }
+
+    // Fall back to default locale in case of errors (English for cronstrue)
+    if (error) {
+        return cronstrue.toString(cronExpression)
+    }
+
+    const locale = selectors.getLocale(data)
+
+    return cronstrue.toString(cronExpression, { locale })
+}
+
+HumanReadableCron.propTypes = {
+    cronExpression: string.isRequired,
+}
+
+export default HumanReadableCron

--- a/src/components/Cron/HumanReadableCron.test.js
+++ b/src/components/Cron/HumanReadableCron.test.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { useGetUserSettings, selectors } from '../../hooks/user-settings'
+import HumanReadableCron from './HumanReadableCron'
+
+jest.mock('../../hooks/user-settings', () => ({
+    useGetUserSettings: jest.fn(() => [() => {}]),
+    selectors: {
+        getLocale: jest.fn(() => ''),
+    },
+}))
+
+describe('<HumanReadableCron>', () => {
+    it('returns nothing while loading', () => {
+        useGetUserSettings.mockImplementationOnce(() => ({
+            loading: true,
+            error: undefined,
+            data: undefined,
+        }))
+        const cronExpression = '0 0 1 ? * *'
+        const wrapper = shallow(
+            <HumanReadableCron cronExpression={cronExpression} />
+        )
+
+        expect(wrapper).toMatchSnapshot()
+    })
+
+    it('falls back to English in case of an error', () => {
+        useGetUserSettings.mockImplementationOnce(() => ({
+            loading: false,
+            error: new Error('error'),
+            data: undefined,
+        }))
+        const cronExpression = '0 0 1 ? * *'
+        const wrapper = shallow(
+            <HumanReadableCron cronExpression={cronExpression} />
+        )
+
+        expect(wrapper.text()).toEqual(expect.stringContaining('At 01:00 AM'))
+    })
+
+    it('renders cron in locale when a locale is found', () => {
+        useGetUserSettings.mockImplementationOnce(() => ({
+            loading: false,
+            error: undefined,
+            data: {},
+        }))
+        selectors.getLocale.mockImplementationOnce(() => 'fr')
+        const cronExpression = '0 0 1 ? * *'
+        const wrapper = shallow(
+            <HumanReadableCron cronExpression={cronExpression} />
+        )
+
+        expect(wrapper.text()).toEqual(expect.stringContaining('À 01:00 AM'))
+    })
+})

--- a/src/components/Cron/__snapshots__/HumanReadableCron.test.js.snap
+++ b/src/components/Cron/__snapshots__/HumanReadableCron.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<HumanReadableCron> returns nothing while loading 1`] = `""`;

--- a/src/components/Cron/index.js
+++ b/src/components/Cron/index.js
@@ -1,0 +1,3 @@
+import HumanReadableCron from './HumanReadableCron'
+
+export { HumanReadableCron }

--- a/src/components/Errors/InlineError.js
+++ b/src/components/Errors/InlineError.js
@@ -1,12 +1,13 @@
 import React from 'react'
 import { string, arrayOf } from 'prop-types'
+import i18n from '@dhis2/d2-i18n'
 import { Title } from '../Title'
 import styles from './InlineError.module.css'
 
 const InlineError = ({ message, details }) => (
     <div className={styles.wrapper}>
-        <Title priority={1}>Something went wrong</Title>
-        <p>The error message was: &quot;{message}&quot;</p>
+        <Title priority={1}>{i18n.t('Something went wrong')}</Title>
+        <p>{`${i18n.t('The error message was')}: ${message}`}</p>
         {details.length > 0 && (
             <React.Fragment>
                 <Title priority={2}>Details</Title>

--- a/src/components/Errors/__snapshots__/InlineError.test.js.snap
+++ b/src/components/Errors/__snapshots__/InlineError.test.js.snap
@@ -10,9 +10,7 @@ exports[`<InlineError> renders correctly 1`] = `
     Something went wrong
   </Title>
   <p>
-    The error message was: "
-    Error
-    "
+    The error message was: Error
   </p>
   <Title
     priority={2}

--- a/src/components/FormFields/CronField.js
+++ b/src/components/FormFields/CronField.js
@@ -1,7 +1,8 @@
 import React from 'react'
-import cronstrue from 'cronstrue'
 import { Field, FormSpy, Input } from '@dhis2/ui-forms'
+import i18n from '@dhis2/d2-i18n'
 import { CronPresetButton } from '../Buttons'
+import { HumanReadableCron } from '../Cron'
 import { requiredCron, validateCron } from '../../services/validators'
 
 // The key under which this field will be sent to the backend
@@ -20,10 +21,14 @@ const CronField = () => (
                         component={Input}
                         name={FIELD_NAME}
                         validate={VALIDATOR}
-                        label="CRON Expression"
+                        label={i18n.t('CRON Expression')}
                         type="text"
                         helpText={
-                            hasValidCron && cronstrue.toString(cronExpression)
+                            hasValidCron && (
+                                <HumanReadableCron
+                                    cronExpression={cronExpression}
+                                />
+                            )
                         }
                         required
                     />

--- a/src/components/FormFields/DelayField.js
+++ b/src/components/FormFields/DelayField.js
@@ -7,16 +7,17 @@ import {
     integer,
     createNumberRange,
 } from '@dhis2/ui-forms'
+import i18n from '@dhis2/d2-i18n'
 
-const LOWER_BOUND = 1
-const UPPER_BOUND = 86400
+const lowerBound = 1
+const upperBound = 86400
 
 // The key under which this field will be sent to the backend
 export const FIELD_NAME = 'delay'
 export const VALIDATOR = composeValidators(
     integer,
     hasValue,
-    createNumberRange(LOWER_BOUND, UPPER_BOUND)
+    createNumberRange(lowerBound, upperBound)
 )
 
 const DelayField = () => (
@@ -24,9 +25,15 @@ const DelayField = () => (
         component={Input}
         name={FIELD_NAME}
         validate={VALIDATOR}
-        label="Delay"
+        label={i18n.t('Delay')}
         type="number"
-        helpText={`Delay in seconds (${LOWER_BOUND} - ${UPPER_BOUND})`}
+        helpText={i18n.t(
+            'Delay in seconds ({{ lowerBound }} - {{ upperBound }})',
+            {
+                lowerBound,
+                upperBound,
+            }
+        )}
         required
     />
 )

--- a/src/components/FormFields/JobNameField.js
+++ b/src/components/FormFields/JobNameField.js
@@ -6,6 +6,7 @@ import {
     hasValue,
     string,
 } from '@dhis2/ui-forms'
+import i18n from '@dhis2/d2-i18n'
 
 // The key under which this field will be sent to the backend
 export const FIELD_NAME = 'name'
@@ -16,7 +17,7 @@ const JobNameField = () => (
         name={FIELD_NAME}
         component={Input}
         validate={VALIDATOR}
-        label="Name"
+        label={i18n.t('Name')}
         type="text"
         required
     />

--- a/src/components/FormFields/JobTypeField.js
+++ b/src/components/FormFields/JobTypeField.js
@@ -1,7 +1,9 @@
 import React from 'react'
 import { Field, SingleSelect } from '@dhis2/ui-forms'
 import { SingleSelectField } from '@dhis2/ui-core'
+import i18n from '@dhis2/d2-i18n'
 import { requiredSingleSelectOption } from '../../services/validators'
+import { jobTypesMap } from '../../services/server-translations'
 import { useGetJobTypes } from '../../hooks/job-types'
 
 // The key under which this field will be sent to the backend
@@ -12,16 +14,21 @@ const JobTypeField = () => {
     const { loading, error, data } = useGetJobTypes()
 
     if (loading) {
-        return <SingleSelectField loading loadingText="Loading job types" />
+        return (
+            <SingleSelectField
+                loading
+                loadingText={i18n.t('Loading job types')}
+            />
+        )
     }
 
     if (error) {
         return <SingleSelectField error helpText={error.message} />
     }
 
-    const options = data.map(({ jobType, name }) => ({
+    const options = data.map(({ jobType }) => ({
         value: jobType,
-        label: name,
+        label: jobTypesMap[jobType],
     }))
 
     return (
@@ -30,7 +37,7 @@ const JobTypeField = () => {
             validate={VALIDATOR}
             component={SingleSelect}
             options={options}
-            label="Job type"
+            label={i18n.t('Job type')}
             required
         />
     )

--- a/src/components/FormFields/LabeledOptionsField.js
+++ b/src/components/FormFields/LabeledOptionsField.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { string } from 'prop-types'
 import { MultiSelectField } from '@dhis2/ui-core'
 import { Field, MultiSelect } from '@dhis2/ui-forms'
+import i18n from '@dhis2/d2-i18n'
 import { useGetLabeledOptions } from '../../hooks/parameter-options'
 
 /**
@@ -28,7 +29,7 @@ const LabeledOptionsField = ({ endpoint, label, name, parameterName }) => {
         return (
             <MultiSelectField
                 disabled
-                helpText="No options available"
+                helpText={i18n.t('No options available')}
                 label={label}
             />
         )

--- a/src/components/FormFields/ParameterFields.js
+++ b/src/components/FormFields/ParameterFields.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { string } from 'prop-types'
 import { Field, Input, Switch } from '@dhis2/ui-forms'
+import i18n from '@dhis2/d2-i18n'
 import { useGetJobTypes, selectors } from '../../hooks/job-types'
 import UnlabeledOptionsField from './UnlabeledOptionsField'
 import LabeledOptionsField from './LabeledOptionsField'
@@ -16,7 +17,7 @@ const ParameterFields = ({ jobType }) => {
     const { loading, error, data } = useGetJobTypes()
 
     if (loading) {
-        return <span>Loading</span>
+        return <span>{i18n.t('Loading')}</span>
     }
 
     if (error) {

--- a/src/components/FormFields/ScheduleField.js
+++ b/src/components/FormFields/ScheduleField.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { string } from 'prop-types'
+import i18n from '@dhis2/d2-i18n'
 import { useGetJobTypes, selectors } from '../../hooks/job-types'
 import CronField from './CronField'
 import DelayField from './DelayField'
@@ -8,7 +9,7 @@ const ScheduleField = ({ jobType }) => {
     const { loading, error, data } = useGetJobTypes()
 
     if (loading) {
-        return <span>Loading job types</span>
+        return <span>{i18n.t('Loading job types')}</span>
     }
 
     if (error) {

--- a/src/components/FormFields/UnlabeledOptionsField.js
+++ b/src/components/FormFields/UnlabeledOptionsField.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { string } from 'prop-types'
+import i18n from '@dhis2/d2-i18n'
 import { MultiSelectField } from '@dhis2/ui-core'
 import { Field, MultiSelect } from '@dhis2/ui-forms'
 import { useGetUnlabeledOptions } from '../../hooks/parameter-options'
@@ -27,7 +28,7 @@ const UnlabeledOptionsField = ({ endpoint, label, name }) => {
         return (
             <MultiSelectField
                 disabled
-                helpText="No options available"
+                helpText={i18n.t('No options available')}
                 label={label}
             />
         )

--- a/src/components/Forms/JobForm.js
+++ b/src/components/Forms/JobForm.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { object, bool, func, shape, string } from 'prop-types'
 import { FormSpy } from '@dhis2/ui-forms'
 import { Button } from '@dhis2/ui-core'
+import i18n from '@dhis2/d2-i18n'
 import { InlineError } from '../Errors'
 import { DiscardFormButton } from '../Buttons'
 import {
@@ -44,10 +45,10 @@ const JobForm = ({
             </div>
             <div>
                 <Button primary type="submit" disabled={pristine}>
-                    Save job
+                    {i18n.t('Save job')}
                 </Button>
                 <DiscardFormButton shouldConfirm={!pristine}>
-                    Cancel
+                    {i18n.t('Cancel')}
                 </DiscardFormButton>
             </div>
         </form>

--- a/src/components/Modal/CronPresetModal.js
+++ b/src/components/Modal/CronPresetModal.js
@@ -10,26 +10,27 @@ import {
     Radio,
     RadioGroup,
 } from '@dhis2/ui-core'
+import i18n from '@dhis2/d2-i18n'
 
 const cronPresets = [
     {
-        label: 'Every hour',
+        label: i18n.t('Every hour'),
         value: '0 0 * ? * *',
     },
     {
-        label: 'Every day at midnight',
+        label: i18n.t('Every day at midnight'),
         value: '0 0 1 ? * *',
     },
     {
-        label: 'Every day at 3 am',
+        label: i18n.t('Every day at 3 am'),
         value: '0 0 3 ? * *',
     },
     {
-        label: 'Every day at noon',
+        label: i18n.t('Every day at noon'),
         value: '0 0 12 ? * MON-FRI',
     },
     {
-        label: 'Every week',
+        label: i18n.t('Every week'),
         value: '0 0 3 ? * MON',
     },
 ]
@@ -39,7 +40,7 @@ const CronPresetModal = ({ setCron, hideModal }) => {
 
     return (
         <Modal open small onClose={hideModal}>
-            <ModalTitle>Choose a preset time/interval</ModalTitle>
+            <ModalTitle>{i18n.t('Choose a preset time/interval')}</ModalTitle>
             <ModalContent>
                 <RadioGroup
                     onChange={({ value }) => setCurrentPreset(value)}
@@ -53,7 +54,7 @@ const CronPresetModal = ({ setCron, hideModal }) => {
             <ModalActions>
                 <ButtonStrip end>
                     <Button secondary onClick={hideModal} name="hide-modal">
-                        Cancel
+                        {i18n.t('Cancel')}
                     </Button>
                     <Button
                         primary
@@ -64,7 +65,7 @@ const CronPresetModal = ({ setCron, hideModal }) => {
                             setCron(currentPreset)
                         }}
                     >
-                        Insert preset
+                        {i18n.t('Insert preset')}
                     </Button>
                 </ButtonStrip>
             </ModalActions>

--- a/src/components/Modal/DeleteJobModal.js
+++ b/src/components/Modal/DeleteJobModal.js
@@ -7,6 +7,7 @@ import {
     ModalActions,
     ButtonStrip,
 } from '@dhis2/ui-core'
+import i18n from '@dhis2/d2-i18n'
 import { RefetchJobsContext } from '../Context'
 import { useDeleteJob } from '../../hooks/jobs'
 
@@ -17,12 +18,12 @@ const DeleteJobModal = ({ id, hideModal }) => {
     return (
         <Modal open small onClose={hideModal}>
             <ModalContent>
-                Are you sure you want to delete this job?
+                {i18n.t('Are you sure you want to delete this job?')}
             </ModalContent>
             <ModalActions>
                 <ButtonStrip end>
                     <Button name="hide-modal" secondary onClick={hideModal}>
-                        Cancel
+                        {i18n.t('Cancel')}
                     </Button>
                     <Button
                         name={`delete-job-${id}`}
@@ -34,7 +35,7 @@ const DeleteJobModal = ({ id, hideModal }) => {
                             })
                         }}
                     >
-                        Delete
+                        {i18n.t('Delete')}
                     </Button>
                 </ButtonStrip>
             </ModalActions>

--- a/src/components/Modal/DiscardFormModal.js
+++ b/src/components/Modal/DiscardFormModal.js
@@ -7,11 +7,14 @@ import {
     ModalActions,
     ButtonStrip,
 } from '@dhis2/ui-core'
+import i18n from '@dhis2/d2-i18n'
 import history from '../../services/history'
 
 const DiscardFormModal = ({ hideModal }) => (
     <Modal open small onClose={hideModal}>
-        <ModalContent>Are you sure you want to discard this form?</ModalContent>
+        <ModalContent>
+            {i18n.t('Are you sure you want to discard this form?')}
+        </ModalContent>
         <ModalActions>
             <ButtonStrip end>
                 <Button
@@ -19,7 +22,7 @@ const DiscardFormModal = ({ hideModal }) => (
                     secondary
                     onClick={hideModal}
                 >
-                    Cancel
+                    {i18n.t('Cancel')}
                 </Button>
                 <Button
                     name="discard-form"
@@ -29,7 +32,7 @@ const DiscardFormModal = ({ hideModal }) => (
                         history.push('/')
                     }}
                 >
-                    Discard
+                    {i18n.t('Discard')}
                 </Button>
             </ButtonStrip>
         </ModalActions>

--- a/src/components/Modal/RunJobModal.js
+++ b/src/components/Modal/RunJobModal.js
@@ -8,6 +8,7 @@ import {
     ModalActions,
     ButtonStrip,
 } from '@dhis2/ui-core'
+import i18n from '@dhis2/d2-i18n'
 import { RefetchJobsContext } from '../Context'
 
 const RunJobModal = ({ id, hideModal }) => {
@@ -22,11 +23,13 @@ const RunJobModal = ({ id, hideModal }) => {
 
     return (
         <Modal open small onClose={hideModal}>
-            <ModalContent>Are you sure you want to run this job?</ModalContent>
+            <ModalContent>
+                {i18n.t('Are you sure you want to run this job?')}
+            </ModalContent>
             <ModalActions>
                 <ButtonStrip end>
                     <Button name="hide-modal" secondary onClick={hideModal}>
-                        Cancel
+                        {i18n.t('Cancel')}
                     </Button>
                     <Button
                         name={`run-job-${id}`}
@@ -38,7 +41,7 @@ const RunJobModal = ({ id, hideModal }) => {
                             })
                         }}
                     >
-                        Run
+                        {i18n.t('Run')}
                     </Button>
                 </ButtonStrip>
             </ModalActions>

--- a/src/hooks/job-types/index.js
+++ b/src/hooks/job-types/index.js
@@ -1,4 +1,4 @@
-import * as selectors from './use-get-job-types.js'
+import * as selectors from './use-get-job-types'
 
 export { selectors }
 export { default as useGetJobTypes } from './use-get-job-types'

--- a/src/hooks/jobs/index.js
+++ b/src/hooks/jobs/index.js
@@ -1,7 +1,7 @@
-import * as selectors from './use-get-jobs.js'
+import * as selectors from './use-get-jobs'
 
 export { selectors }
-export { default as useGetJobs } from './use-get-jobs.js'
-export { default as useToggleJob } from './use-toggle-job.js'
-export { default as useDeleteJob } from './use-delete-job.js'
-export { default as useCreateJob } from './use-create-job.js'
+export { default as useGetJobs } from './use-get-jobs'
+export { default as useToggleJob } from './use-toggle-job'
+export { default as useDeleteJob } from './use-delete-job'
+export { default as useCreateJob } from './use-create-job'

--- a/src/hooks/me/index.js
+++ b/src/hooks/me/index.js
@@ -1,4 +1,4 @@
-import * as selectors from './use-get-me.js'
+import * as selectors from './use-get-me'
 
 export { selectors }
-export { default as useGetMe } from './use-get-me.js'
+export { default as useGetMe } from './use-get-me'

--- a/src/hooks/me/use-get-me.test.js
+++ b/src/hooks/me/use-get-me.test.js
@@ -1,5 +1,5 @@
 import { useDataQuery } from '@dhis2/app-runtime'
-import useGetMe, { getAuthorized } from './use-get-me.js'
+import useGetMe, { getAuthorized } from './use-get-me'
 
 jest.mock('@dhis2/app-runtime', () => ({
     useDataQuery: jest.fn(),

--- a/src/hooks/user-settings/index.js
+++ b/src/hooks/user-settings/index.js
@@ -1,0 +1,4 @@
+import * as selectors from './use-get-user-settings'
+
+export { selectors }
+export { default as useGetUserSettings } from './use-get-user-settings'

--- a/src/hooks/user-settings/use-get-user-settings.js
+++ b/src/hooks/user-settings/use-get-user-settings.js
@@ -1,0 +1,33 @@
+import { useDataQuery } from '@dhis2/app-runtime'
+
+const query = {
+    userSettings: {
+        resource: 'userSettings',
+    },
+}
+
+const useGetUserSettings = () => {
+    const { loading, error, data } = useDataQuery(query)
+
+    if (data && data.userSettings) {
+        return { loading, error, data: data.userSettings }
+    }
+
+    return { loading, error, data }
+}
+
+export default useGetUserSettings
+
+/**
+ * Selectors
+ */
+
+export const getLocale = data => {
+    const { keyUiLocale } = data
+
+    if (!keyUiLocale) {
+        return ''
+    }
+
+    return keyUiLocale
+}

--- a/src/hooks/user-settings/use-get-user-settings.test.js
+++ b/src/hooks/user-settings/use-get-user-settings.test.js
@@ -1,0 +1,13 @@
+import { getLocale } from './use-get-user-settings'
+
+describe('getLocale', () => {
+    it('should return empty string if there is no keyUiLocale', () => {
+        expect(getLocale({})).toBe('')
+    })
+
+    it('should return the keyUiLocale if it is in the data', () => {
+        const keyUiLocale = 'en'
+
+        expect(getLocale({ keyUiLocale })).toBe('en')
+    })
+})

--- a/src/pages/JobAdd/JobAdd.js
+++ b/src/pages/JobAdd/JobAdd.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Card } from '@dhis2/ui-core'
+import i18n from '@dhis2/d2-i18n'
 import { Title } from '../../components/Title'
 import { Arrange } from '../../components/Arrange'
 import { DiscardFormButton } from '../../components/Buttons'
@@ -15,14 +16,14 @@ const JobAdd = () => {
     return (
         <React.Fragment>
             <DiscardFormButton shouldConfirm={!isPristine}>
-                Back to all jobs
+                {i18n.t('Back to all jobs')}
             </DiscardFormButton>
-            <Title priority={2}>New Job</Title>
+            <Title priority={2}>{i18n.t('New Job')}</Title>
             <Card>
                 <Arrange>
-                    <Title priority={3}>Configuration</Title>
+                    <Title priority={3}>{i18n.t('Configuration')}</Title>
                     <Info />
-                    <a href={infoLink}>About job configuration</a>
+                    <a href={infoLink}>{i18n.t('About job configuration')}</a>
                 </Arrange>
                 <JobFormContainer setIsPristine={setIsPristine} />
             </Card>

--- a/src/pages/JobList/DeleteJobMenuItem.js
+++ b/src/pages/JobList/DeleteJobMenuItem.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { string } from 'prop-types'
 import { MenuItem } from '@dhis2/ui-core'
+import i18n from '@dhis2/d2-i18n'
 import { DeleteJobModal } from '../../components/Modal'
 
 const DeleteJobMenuItem = ({ id }) => {
@@ -14,7 +15,7 @@ const DeleteJobMenuItem = ({ id }) => {
                 onClick={() => {
                     setShowModal(true)
                 }}
-                label="Delete"
+                label={i18n.t('Delete')}
             />
             {showModal && (
                 <DeleteJobModal id={id} hideModal={() => setShowModal(false)} />

--- a/src/pages/JobList/EditJobMenuItem.js
+++ b/src/pages/JobList/EditJobMenuItem.js
@@ -1,10 +1,15 @@
 import React from 'react'
 import { string } from 'prop-types'
 import { MenuItem } from '@dhis2/ui-core'
+import i18n from '@dhis2/d2-i18n'
 import history from '../../services/history'
 
 const EditJobMenuItem = ({ id }) => (
-    <MenuItem dense onClick={() => history.push(`/edit/${id}`)} label="Edit" />
+    <MenuItem
+        dense
+        onClick={() => history.push(`/edit/${id}`)}
+        label={i18n.t('Edit')}
+    />
 )
 
 EditJobMenuItem.propTypes = {

--- a/src/pages/JobList/JobList.js
+++ b/src/pages/JobList/JobList.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { func, bool, object, arrayOf, string } from 'prop-types'
 import { Card, Switch, Input, Button } from '@dhis2/ui-core'
+import i18n from '@dhis2/d2-i18n'
 import { Info } from '../../components/Icons'
 import history from '../../services/history'
 import JobListTable from './JobListTable'
@@ -18,13 +19,13 @@ const JobList = ({
     return (
         <React.Fragment>
             <div className={styles.titleContainer}>
-                <h1 className={styles.title}>Scheduled Jobs</h1>
+                <h1 className={styles.title}>{i18n.t('Scheduled jobs')}</h1>
                 <Info />
             </div>
             <Card>
                 <div className={styles.controlContainer}>
                     <Input
-                        placeholder="Filter jobs"
+                        placeholder={i18n.t('Filter jobs')}
                         onChange={({ value }) => {
                             setJobFilter(value)
                         }}
@@ -34,7 +35,7 @@ const JobList = ({
                         <Switch
                             checked={showSystemJobs}
                             disabled={isLoading}
-                            label="Show system jobs"
+                            label={i18n.t('Show system jobs')}
                             onChange={({ checked }) => {
                                 setShowSystemJobs(checked)
                             }}
@@ -44,7 +45,7 @@ const JobList = ({
                                 history.push('/add')
                             }}
                         >
-                            New job
+                            {i18n.t('New job')}
                         </Button>
                     </div>
                 </div>

--- a/src/pages/JobList/JobListActions.js
+++ b/src/pages/JobList/JobListActions.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { string } from 'prop-types'
 import { Menu, DropdownButton } from '@dhis2/ui-core'
+import i18n from '@dhis2/d2-i18n'
 import EditJobMenuItem from './EditJobMenuItem'
 import RunJobMenuItem from './RunJobMenuItem'
 import DeleteJobMenuItem from './DeleteJobMenuItem'
@@ -16,7 +17,7 @@ const JobListActions = ({ id }) => (
             </Menu>
         }
     >
-        Actions
+        {i18n.t('Actions')}
     </DropdownButton>
 )
 

--- a/src/pages/JobList/JobListContainer.js
+++ b/src/pages/JobList/JobListContainer.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { CircularLoader } from '@dhis2/ui-core'
+import i18n from '@dhis2/d2-i18n'
 import { selectors, useGetJobs } from '../../hooks/jobs'
 import { AbsoluteCenter } from '../../components/AbsoluteCenter'
 import { FullscreenError } from '../../components/Errors'
@@ -16,7 +17,7 @@ const JobListContainer = () => {
         return (
             <AbsoluteCenter vertical>
                 <CircularLoader />
-                Loading jobs
+                {i18n.t('Loading jobs')}
             </AbsoluteCenter>
         )
     }

--- a/src/pages/JobList/JobListTable.js
+++ b/src/pages/JobList/JobListTable.js
@@ -9,25 +9,26 @@ import {
     TableCellHead,
     TableBody,
 } from '@dhis2/ui-core'
+import i18n from '@dhis2/d2-i18n'
 import JobListTableItem from './JobListTableItem'
 
 const JobListTable = ({ jobIds, jobEntities }) => (
     <Table>
         <TableHead>
             <TableRowHead>
-                <TableCellHead>Job name</TableCellHead>
-                <TableCellHead>Type</TableCellHead>
-                <TableCellHead>Schedule</TableCellHead>
-                <TableCellHead>Next run</TableCellHead>
-                <TableCellHead>Status</TableCellHead>
-                <TableCellHead>On/off</TableCellHead>
+                <TableCellHead>{i18n.t('Job name')}</TableCellHead>
+                <TableCellHead>{i18n.t('Type')}</TableCellHead>
+                <TableCellHead>{i18n.t('Schedule')}</TableCellHead>
+                <TableCellHead>{i18n.t('Next run')}</TableCellHead>
+                <TableCellHead>{i18n.t('Status')}</TableCellHead>
+                <TableCellHead>{i18n.t('On/off')}</TableCellHead>
                 <TableCellHead />
             </TableRowHead>
         </TableHead>
         <TableBody>
             {jobIds.length === 0 ? (
                 <TableRow>
-                    <TableCell>No jobs to display</TableCell>
+                    <TableCell>{i18n.t('No jobs to display')}</TableCell>
                 </TableRow>
             ) : (
                 jobIds.map(id => (

--- a/src/pages/JobList/JobListTableItem.js
+++ b/src/pages/JobList/JobListTableItem.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { bool, shape, string, number } from 'prop-types'
 import { TableRow, TableCell } from '@dhis2/ui-core'
+import { jobTypesMap } from '../../services/server-translations'
 import { ToggleJobSwitch } from '../../components/Switches'
 import JobListActions from './JobListActions'
 import JobStatus from './JobStatus'
@@ -22,7 +23,7 @@ const JobListTableItem = ({
 }) => (
     <TableRow>
         <TableCell>{displayName}</TableCell>
-        <TableCell>{jobType}</TableCell>
+        <TableCell>{jobTypesMap[jobType]}</TableCell>
         <TableCell>
             <JobSchedule
                 cronExpression={cronExpression}

--- a/src/pages/JobList/JobListTableItem.test.js
+++ b/src/pages/JobList/JobListTableItem.test.js
@@ -7,7 +7,7 @@ describe('<JobListTableItem>', () => {
         const job = {
             id: '1',
             displayName: 'Name',
-            jobType: 'Type',
+            jobType: 'SEND_SCHEDULED_MESSAGE',
             cronExpression: '0 0 * ? * *',
             jobStatus: 'ENABLED',
             nextExecutionTime: '2100-10-10T14:48:00',
@@ -23,7 +23,7 @@ describe('<JobListTableItem>', () => {
         const job = {
             id: '1',
             displayName: 'Name',
-            jobType: 'Type',
+            jobType: 'CONTINUOUS_ANALYTICS_TABLE',
             jobStatus: 'ENABLED',
             nextExecutionTime: '',
             enabled: true,

--- a/src/pages/JobList/JobNextRun.js
+++ b/src/pages/JobList/JobNextRun.js
@@ -1,5 +1,6 @@
 import moment from 'moment'
 import { string, bool } from 'prop-types'
+import i18n from '@dhis2/d2-i18n'
 
 const JobNextRun = ({ nextExecutionTime, enabled }) => {
     if (!enabled || !nextExecutionTime) {
@@ -23,7 +24,7 @@ const JobNextRun = ({ nextExecutionTime, enabled }) => {
      */
 
     if (nextRunIsInPast) {
-        return 'Not scheduled'
+        return i18n.t('Not scheduled')
     }
 
     return now.to(nextRun)

--- a/src/pages/JobList/JobSchedule.js
+++ b/src/pages/JobList/JobSchedule.js
@@ -1,12 +1,14 @@
-import cronstrue from 'cronstrue'
+import React from 'react'
 import { string, number } from 'prop-types'
+import i18n from '@dhis2/d2-i18n'
+import { HumanReadableCron } from '../../components/Cron'
 
 const JobSchedule = ({ cronExpression, schedulingType, delay }) => {
     switch (schedulingType) {
         case 'CRON':
-            return cronstrue.toString(cronExpression)
+            return <HumanReadableCron cronExpression={cronExpression} />
         case 'FIXED_DELAY':
-            return delay + ' seconds after last run'
+            return i18n.t('{{ delay }} seconds after last run', { delay })
         default:
             // Unrecognised or invalid type
             return '-'

--- a/src/pages/JobList/JobSchedule.test.js
+++ b/src/pages/JobList/JobSchedule.test.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import JobSchedule from './JobSchedule'
+
+describe('<JobSchedule>', () => {
+    it('renders a human readable cron for the CRON scheduling type', () => {
+        const wrapper = shallow(
+            <JobSchedule
+                schedulingType="CRON"
+                cronExpression="cronExpression"
+            />
+        )
+
+        expect(wrapper).toMatchSnapshot()
+    })
+
+    it('renders a delay for the FIXED_DELAY scheduling type', () => {
+        const wrapper = shallow(
+            <JobSchedule schedulingType="FIXED_DELAY" delay={1000} />
+        )
+
+        expect(wrapper.text()).toEqual(
+            expect.stringContaining('1000 seconds after last run')
+        )
+    })
+
+    it('renders a dash for an unrecognised scheduling type', () => {
+        const wrapper = shallow(<JobSchedule schedulingType="NONEXISTENT" />)
+
+        expect(wrapper.text()).toEqual(expect.stringContaining('-'))
+    })
+})

--- a/src/pages/JobList/JobStatus.js
+++ b/src/pages/JobList/JobStatus.js
@@ -1,20 +1,22 @@
 import React from 'react'
 import { string } from 'prop-types'
 import { Tag } from '@dhis2/ui-core'
+import { jobStatusMap } from '../../services/server-translations'
 
 const JobStatus = ({ status }) => {
     switch (status) {
         case 'STOPPED':
         case 'DISABLED':
-            return <Tag>{status}</Tag>
+            return <Tag>{jobStatusMap[status]}</Tag>
         case 'RUNNING':
         case 'NOT_STARTED':
         case 'SCHEDULED':
-            return <Tag neutral>{status}</Tag>
+            return <Tag neutral>{jobStatusMap[status]}</Tag>
         case 'FAILED':
-            return <Tag negative>{status}</Tag>
+            return <Tag negative>{jobStatusMap[status]}</Tag>
         case 'DONE':
-            return <Tag positive>{status}</Tag>
+            return <Tag positive>{jobStatusMap[status]}</Tag>
+        // Unrecognised status
         default:
             return null
     }

--- a/src/pages/JobList/RunJobMenuItem.js
+++ b/src/pages/JobList/RunJobMenuItem.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { string } from 'prop-types'
 import { MenuItem } from '@dhis2/ui-core'
+import i18n from '@dhis2/d2-i18n'
 import { RunJobModal } from '../../components/Modal'
 
 const RunJobMenuItem = ({ id }) => {
@@ -13,7 +14,7 @@ const RunJobMenuItem = ({ id }) => {
                 onClick={() => {
                     setShowModal(true)
                 }}
-                label="Run manually"
+                label={i18n.t('Run manually')}
             />
             {showModal && (
                 <RunJobModal id={id} hideModal={() => setShowModal(false)} />

--- a/src/pages/JobList/__snapshots__/JobListTableItem.test.js.snap
+++ b/src/pages/JobList/__snapshots__/JobListTableItem.test.js.snap
@@ -12,7 +12,7 @@ exports[`<JobListTableItem> renders cron jobs correctly 1`] = `
   <TableCell
     dataTest="dhis2-uicore-tablecell"
   >
-    Type
+    Send scheduled message
   </TableCell>
   <TableCell
     dataTest="dhis2-uicore-tablecell"
@@ -67,7 +67,7 @@ exports[`<JobListTableItem> renders fixed delay jobs correctly 1`] = `
   <TableCell
     dataTest="dhis2-uicore-tablecell"
   >
-    Type
+    Continuous analytics table
   </TableCell>
   <TableCell
     dataTest="dhis2-uicore-tablecell"

--- a/src/pages/JobList/__snapshots__/JobSchedule.test.js.snap
+++ b/src/pages/JobList/__snapshots__/JobSchedule.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<JobSchedule> renders a human readable cron for the CRON scheduling type 1`] = `
+<HumanReadableCron
+  cronExpression="cronExpression"
+/>
+`;

--- a/src/pages/JobList/__snapshots__/JobStatus.test.js.snap
+++ b/src/pages/JobList/__snapshots__/JobStatus.test.js.snap
@@ -4,7 +4,7 @@ exports[`<JobStatus> renders correctly for DISABLED status 1`] = `
 <Tag
   dataTest="dhis2-uicore-tag"
 >
-  DISABLED
+  Disabled
 </Tag>
 `;
 
@@ -13,7 +13,7 @@ exports[`<JobStatus> renders correctly for DONE status 1`] = `
   dataTest="dhis2-uicore-tag"
   positive={true}
 >
-  DONE
+  Done
 </Tag>
 `;
 
@@ -22,7 +22,7 @@ exports[`<JobStatus> renders correctly for FAILED status 1`] = `
   dataTest="dhis2-uicore-tag"
   negative={true}
 >
-  FAILED
+  Failed
 </Tag>
 `;
 
@@ -31,7 +31,7 @@ exports[`<JobStatus> renders correctly for NOT_STARTED status 1`] = `
   dataTest="dhis2-uicore-tag"
   neutral={true}
 >
-  NOT_STARTED
+  Not started
 </Tag>
 `;
 
@@ -40,7 +40,7 @@ exports[`<JobStatus> renders correctly for RUNNING status 1`] = `
   dataTest="dhis2-uicore-tag"
   neutral={true}
 >
-  RUNNING
+  Running
 </Tag>
 `;
 
@@ -49,7 +49,7 @@ exports[`<JobStatus> renders correctly for SCHEDULED status 1`] = `
   dataTest="dhis2-uicore-tag"
   neutral={true}
 >
-  SCHEDULED
+  Scheduled
 </Tag>
 `;
 
@@ -57,7 +57,7 @@ exports[`<JobStatus> renders correctly for STOPPED status 1`] = `
 <Tag
   dataTest="dhis2-uicore-tag"
 >
-  STOPPED
+  Stopped
 </Tag>
 `;
 

--- a/src/services/server-translations/index.js
+++ b/src/services/server-translations/index.js
@@ -1,0 +1,4 @@
+import jobTypesMap from './jobTypesMap'
+import jobStatusMap from './jobStatusMap'
+
+export { jobTypesMap, jobStatusMap }

--- a/src/services/server-translations/jobStatusMap.js
+++ b/src/services/server-translations/jobStatusMap.js
@@ -1,0 +1,13 @@
+import i18n from '@dhis2/d2-i18n'
+
+const jobStatusMap = {
+    DISABLED: i18n.t('Disabled'),
+    DONE: i18n.t('Done'),
+    FAILED: i18n.t('Failed'),
+    NOT_STARTED: i18n.t('Not started'),
+    RUNNING: i18n.t('Running'),
+    SCHEDULED: i18n.t('Scheduled'),
+    STOPPED: i18n.t('Stopped'),
+}
+
+export default jobStatusMap

--- a/src/services/server-translations/jobTypesMap.js
+++ b/src/services/server-translations/jobTypesMap.js
@@ -1,0 +1,25 @@
+import i18n from '@dhis2/d2-i18n'
+
+const jobTypesMap = {
+    ANALYTICS_TABLE: i18n.t('Analytics table'),
+    CONTINUOUS_ANALYTICS_TABLE: i18n.t('Continuous analytics table'),
+    CREDENTIALS_EXPIRY_ALERT: i18n.t('Credentials expiry alert'),
+    DATA_INTEGRITY: i18n.t('Data integrity'),
+    DATA_SET_NOTIFICATION: i18n.t('Dataset notification'),
+    DATA_STATISTICS: i18n.t('Data statistics'),
+    DATA_SYNC: i18n.t('Data sync'),
+    EVENT_PROGRAMS_DATA_SYNC: i18n.t('Event programs data sync'),
+    FILE_RESOURCE_CLEANUP: i18n.t('File resource clean up'),
+    META_DATA_SYNC: i18n.t('Meta data sync'),
+    MONITORING: i18n.t('Monitoring'),
+    PREDICTOR: i18n.t('Predictor'),
+    PROGRAM_NOTIFICATIONS: i18n.t('Program notifications'),
+    PUSH_ANALYSIS: i18n.t('Push analysis'),
+    REMOVE_EXPIRED_RESERVED_VALUES: i18n.t('Remove expired reserved values'),
+    RESOURCE_TABLE: i18n.t('Resource table'),
+    SEND_SCHEDULED_MESSAGE: i18n.t('Send scheduled message'),
+    TRACKER_PROGRAMS_DATA_SYNC: i18n.t('Tracker programs data sync'),
+    VALIDATION_RESULTS_NOTIFICATION: i18n.t('Validation results notification'),
+}
+
+export default jobTypesMap

--- a/src/services/validators/required-cron.js
+++ b/src/services/validators/required-cron.js
@@ -1,3 +1,4 @@
+import i18n from '@dhis2/d2-i18n'
 import validateCron from './validate-cron'
 
 const requiredCron = value => {
@@ -5,11 +6,11 @@ const requiredCron = value => {
     const isFilled = isString && value.length > 0
 
     if (!isFilled) {
-        return 'A CRON expression is required'
+        return i18n.t('A CRON expression is required')
     }
 
     if (!validateCron(value)) {
-        return 'Please enter a valid CRON expression'
+        return i18n.t('Please enter a valid CRON expression')
     }
 
     return undefined

--- a/src/services/validators/required-single-select-option.js
+++ b/src/services/validators/required-single-select-option.js
@@ -1,4 +1,6 @@
-const invalidOptionMessage = 'Please select an option'
+import i18n from '@dhis2/d2-i18n'
+
+const invalidOptionMessage = i18n.t('Please select an option')
 
 const requiredSingleSelectOption = value => {
     const isObject = typeof value === 'object'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1247,15 +1247,7 @@
     semver "^7.1.1"
     yargs "^15.1.0"
 
-"@dhis2/d2-i18n@1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.0.5.tgz#9148af1bc95e9442bcae66136b8f80146406a43f"
-  integrity sha512-nz1JtDLNn6hOoSg84C1iYRBr11O/ljMdczEqq0/j/gQy9wRs80Z7lExwItclHgS7t6ESWCa6+OFkwgRCOKF2ew==
-  dependencies:
-    i18next "^10.3"
-    moment "^2.24.0"
-
-"@dhis2/d2-i18n@^1.0.5":
+"@dhis2/d2-i18n@1.0.5", "@dhis2/d2-i18n@^1.0.5", "@dhis2/d2-i18n@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.0.6.tgz#2914be8acf296f3a6bf7b51c76c46da6a120b0ff"
   integrity sha512-7YdA4ppFosjuyf7ZMm47BrdsA5TWLM9lmS0lUPgjcCVeeWfUgagqzf4W5JGB9XQ3w1vzK+yy5zH2Ij8IgRAGhA==


### PR DESCRIPTION
This adds translations to the refactor branch. Note that the HumanReadableCron component fires off a request every time it is rendered. This happens with other components as well, but I'll address it later (eventually the app-platform should cache these requests, so this PR builds on that assumption, and I'll add an intermediary fix in a separate PR).

Todo:

- [x] Update tests
- [x] Check if dhis2/i18n needs to be added as a dep explicitly ([yes it should](https://dhis2.slack.com/archives/CLJSVA1RV/p1585730532018900))
- [x] Localize strings from the backend
- [x] Check localisation for cronstrue and moment ([see useLocale hook](https://github.com/dhis2/app-platform/blob/master/adapter/src/AuthBoundary/index.js#L16))

Later:

- Localize parameter field labels from the backend (first I want to know why there is a difference between jobtypes retrieved from 'jobConfigurations' and the jobtypes we get from  'jobConfigurations/jobTypes')
