### PR TITLE
chore: update eslint config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,5 +4,6 @@
 coverage
 node_modules
 public
+src/locales
 
 d2.config.js

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -12,7 +12,29 @@ module.exports = {
     ],
     rules: {
         'compat/compat': 'warn',
-        'import/order': ['error', { 'newlines-between': 'never' }],
+        'import/export': 'error',
+        'import/extensions': ['error', 'never'],
+        'import/first': 'error',
+        'import/newline-after-import': 'error',
+        'import/no-cycle': 'error',
+        'import/no-duplicates': 'error',
+        'import/no-internal-modules': [
+            'error',
+            {
+                allow: [
+                    '**/components/*',
+                    '**/hooks/*',
+                    '**/pages/*',
+                    '**/services/*',
+                    'cronstrue/*'
+                ],
+            },
+        ],
+        'import/no-named-as-default': 'error',
+        'import/no-named-as-default-member': 'error',
+        'import/no-named-default': 'error',
+        'import/no-self-import': 'error',
+        'import/no-unassigned-import': ['error', { allow: ['**/*.css'] }],
         'import/no-unused-modules': [
             'error',
             {
@@ -25,6 +47,8 @@ module.exports = {
                 ],
             },
         ],
+        'import/no-useless-path-segments': 'error',
+        'import/order': ['error', { 'newlines-between': 'never' }],
         'react/require-default-props': 'warn',
         'react-hooks/rules-of-hooks': 'error',
         'react-hooks/exhaustive-deps': 'warn',

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -2,9 +2,7 @@ const { config } = require('@dhis2/cli-style')
 
 module.exports = {
     root: true,
-    plugins: [
-        "react-hooks"
-    ],
+    plugins: ['react-hooks'],
     extends: [
         config.eslintReact,
         'plugin:import/errors',
@@ -13,10 +11,22 @@ module.exports = {
         'plugin:compat/recommended',
     ],
     rules: {
-        'compat/compat': 1,
+        'compat/compat': 'warn',
         'import/order': ['error', { 'newlines-between': 'never' }],
-        'react/require-default-props': 2,
-        "react-hooks/rules-of-hooks": "error",
-        "react-hooks/exhaustive-deps": "warn"
-    }
+        'import/no-unused-modules': [
+            'error',
+            {
+                unusedExports: true,
+                missingExports: true,
+                ignoreExports: [
+                    '**/*.test.js',
+                    'src/setupTests.js',
+                    'src/components/App/index.js',
+                ],
+            },
+        ],
+        'react/require-default-props': 'warn',
+        'react-hooks/rules-of-hooks': 'error',
+        'react-hooks/exhaustive-deps': 'warn',
+    },
 }

--- a/src/components/Buttons/index.js
+++ b/src/components/Buttons/index.js
@@ -1,5 +1,4 @@
-import DeleteJobButton from './DeleteJobButton'
 import CronPresetButton from './CronPresetButton'
 import DiscardFormButton from './DiscardFormButton'
 
-export { DeleteJobButton, DiscardFormButton, CronPresetButton }
+export { DiscardFormButton, CronPresetButton }

--- a/src/components/FormFields/DelayField.js
+++ b/src/components/FormFields/DelayField.js
@@ -13,8 +13,8 @@ const lowerBound = 1
 const upperBound = 86400
 
 // The key under which this field will be sent to the backend
-export const FIELD_NAME = 'delay'
-export const VALIDATOR = composeValidators(
+const FIELD_NAME = 'delay'
+const VALIDATOR = composeValidators(
     integer,
     hasValue,
     createNumberRange(lowerBound, upperBound)

--- a/src/components/NoticeBox/NoticeBoxIcon.test.js
+++ b/src/components/NoticeBox/NoticeBoxIcon.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import NoticeBoxIcon from './NoticeBoxIcon.js'
+import NoticeBoxIcon from './NoticeBoxIcon'
 
 describe('NoticeBoxIcon', () => {
     it('should render info icon by default', () => {

--- a/src/components/NoticeBox/NoticeBoxMessage.test.js
+++ b/src/components/NoticeBox/NoticeBoxMessage.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import NoticeBoxMessage from './NoticeBoxMessage.js'
+import NoticeBoxMessage from './NoticeBoxMessage'
 
 describe('NoticeBoxMessage', () => {
     it('should return null when there are no children', () => {

--- a/src/components/NoticeBox/NoticeBoxTitle.test.js
+++ b/src/components/NoticeBox/NoticeBoxTitle.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import NoticeBoxTitle from './NoticeBoxTitle.js'
+import NoticeBoxTitle from './NoticeBoxTitle'
 
 describe('NoticeBoxTitle', () => {
     it('should return null when there is no title', () => {

--- a/src/hooks/job-types/index.js
+++ b/src/hooks/job-types/index.js
@@ -1,4 +1,4 @@
 import * as selectors from './use-get-job-types'
+import useGetJobTypes from './use-get-job-types'
 
-export { selectors }
-export { default as useGetJobTypes } from './use-get-job-types'
+export { selectors, useGetJobTypes }

--- a/src/hooks/jobs/index.js
+++ b/src/hooks/jobs/index.js
@@ -1,7 +1,7 @@
 import * as selectors from './use-get-jobs'
+import useGetJobs from './use-get-jobs'
+import useToggleJob from './use-toggle-job'
+import useDeleteJob from './use-delete-job'
+import useCreateJob from './use-create-job'
 
-export { selectors }
-export { default as useGetJobs } from './use-get-jobs'
-export { default as useToggleJob } from './use-toggle-job'
-export { default as useDeleteJob } from './use-delete-job'
-export { default as useCreateJob } from './use-create-job'
+export { selectors, useGetJobs, useToggleJob, useDeleteJob, useCreateJob }

--- a/src/hooks/me/index.js
+++ b/src/hooks/me/index.js
@@ -1,4 +1,4 @@
 import * as selectors from './use-get-me'
+import useGetMe from './use-get-me'
 
-export { selectors }
-export { default as useGetMe } from './use-get-me'
+export { selectors, useGetMe }

--- a/src/hooks/parameter-options/index.js
+++ b/src/hooks/parameter-options/index.js
@@ -1,2 +1,4 @@
-export { default as useGetLabeledOptions } from './use-get-labeled-options'
-export { default as useGetUnlabeledOptions } from './use-get-unlabeled-options'
+import useGetLabeledOptions from './use-get-labeled-options'
+import useGetUnlabeledOptions from './use-get-unlabeled-options'
+
+export { useGetLabeledOptions, useGetUnlabeledOptions }

--- a/src/hooks/user-settings/index.js
+++ b/src/hooks/user-settings/index.js
@@ -1,4 +1,4 @@
 import * as selectors from './use-get-user-settings'
+import useGetUserSettings from './use-get-user-settings'
 
-export { selectors }
-export { default as useGetUserSettings } from './use-get-user-settings'
+export { selectors, useGetUserSettings }

--- a/src/services/history/index.js
+++ b/src/services/history/index.js
@@ -1,1 +1,3 @@
-export { default } from './history'
+import history from './history'
+
+export default history


### PR DESCRIPTION
Enabling some useful rules, see: https://github.com/benmosher/eslint-plugin-import. This adds checks for common import mistakes/anti-patterns (like no cyclical dependencies, no unused modules, etc.). Other than that it enables some style rules that allow us to have to think less about how we're writing our imports, since `eslint --fix` will keep it consistent for us.

* The `import/no-internal-modules` rule enforces the existing repo structure. It ensures that the index.js of every folder in `components`, `hooks`, `pages` and `services` is always the external boundary. Which will hopefully make the interaction between the different parts of the app easier to reason about, we'll see how it works out in practice though.
* I've kept the plugin's bundled warnings and errors. We're setting most of them manually, but I figured it couldn't hurt to have their settings as a base/default.