### PR TITLE
fix: revert to old translation strategy

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-01-29T15:16:04.305Z\n"
-"PO-Revision-Date: 2020-01-29T15:16:04.305Z\n"
+"POT-Creation-Date: 2020-04-28T12:20:25.090Z\n"
+"PO-Revision-Date: 2020-04-28T12:20:25.090Z\n"
 
 msgid "Scheduler"
 msgstr ""
@@ -27,6 +27,9 @@ msgid "Are you sure you want to delete this job?"
 msgstr ""
 
 msgid "Add new job"
+msgstr ""
+
+msgid "Add job"
 msgstr ""
 
 msgid "Required"
@@ -153,22 +156,4 @@ msgid "Could not run job"
 msgstr ""
 
 msgid "You are not authorized to use this app"
-msgstr ""
-
-msgid "Custom"
-msgstr ""
-
-msgid "Every hour"
-msgstr ""
-
-msgid "Every day midnight"
-msgstr ""
-
-msgid "Every day at three am"
-msgstr ""
-
-msgid "Every weekday at noon"
-msgstr ""
-
-msgid "Every week"
 msgstr ""

--- a/src/actions/epics.js
+++ b/src/actions/epics.js
@@ -55,8 +55,7 @@ const loadJobs = action$ =>
 const addJob = action$ =>
     action$.pipe(
         ofType(actions.JOB_POST),
-        concatMap(action => {
-            return api
+        concatMap(action => api
                 .postJob(action.payload.job)
                 .then(result => {
                     history.replace('/');
@@ -65,16 +64,15 @@ const addJob = action$ =>
                         payload: { result },
                     };
                 })
-                .catch(error => ({ type: actions.JOB_POST_ERROR, payload: { error } }))
-        }),
+                .catch(error => ({ type: actions.JOB_POST_ERROR, payload: { error } }))),
     );
 
 const saveJob = action$ =>
     action$.pipe(
         ofType(actions.JOB_SAVE),
         switchMap(action => {
-            const { jobParameters, ...job } = action.payload.job
-            const toBeSaved = { ...job, jobParameters: jobParameters || {} }
+            const { jobParameters, ...job } = action.payload.job;
+            const toBeSaved = { ...job, jobParameters: jobParameters || {} };
 
             return api
                 .saveJob(toBeSaved)
@@ -85,7 +83,7 @@ const saveJob = action$ =>
                         payload: { result },
                     };
                 })
-                .catch(error => ({ type: actions.JOB_SAVE_ERROR, payload: { error } }))
+                .catch(error => ({ type: actions.JOB_SAVE_ERROR, payload: { error } }));
         }),
     );
 

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -7,34 +7,28 @@ const JOBSTATUSES = ['RUNNING', 'COMPLETED', 'STOPPED', 'SCHEDULED', 'DISABLED',
 const createJobTypeMapping = (cb, jobTypes) => jobTypes.reduce(
     (mapping, jobType) => ({ ...mapping, [jobType.jobType]: cb(jobType) }),
     {},
-)
+);
 
 
 export const getConfiguration = () => getD2Instance()
     .then(d2 => d2.Api.getApi())
     .then(api => api.get(JOB_PARAMETERS_ENDPOINT))
     .then(({ jobTypes: response }) => {
-        const jobTypes = response.map(({ jobType }) => jobType)
+        const jobTypes = response.map(({ jobType }) => jobType);
 
         const jobTypeToSchedulingTypes = createJobTypeMapping(
             ({ schedulingType }) => schedulingType,
             response,
-        )
+        );
 
-        const jobTypeNames = createJobTypeMapping(
-            ({ name }) => name,
-            response,
-        )
-
-        const jobParameters = createJobTypeMapping(
+        const parameters = createJobTypeMapping(
             ({ jobParameters }) => jobParameters || [],
             response,
-        )
+        );
 
         return {
             jobStatuses: JOBSTATUSES,
-            jobParameters,
-            jobTypeNames,
+            jobParameters: parameters,
             jobTypes,
             jobTypeToSchedulingTypes,
         };
@@ -101,17 +95,17 @@ export const postJob = job =>
                 name: job.name,
                 jobType: job.type,
                 jobParameters: job.parameters || {},
-            }
+            };
 
             if (job.cronExpression) {
-                toBeSaved.cronExpression = job.cronExpression
+                toBeSaved.cronExpression = job.cronExpression;
             }
 
             if (job.delay) {
-                toBeSaved.delay = job.delay
+                toBeSaved.delay = job.delay;
             }
 
-            return instance.Api.getApi().post('jobConfigurations', toBeSaved)
+            return instance.Api.getApi().post('jobConfigurations', toBeSaved);
         })
         .catch(error => {
             throw error;
@@ -125,17 +119,17 @@ export const saveJob = job =>
                 enabled: job.enabled,
                 jobType: job.type || job.jobType,
                 jobParameters: job.parameters || job.jobParameters,
-            }
+            };
 
             if (job.cronExpression) {
-                toBeSaved.cronExpression = job.cronExpression
+                toBeSaved.cronExpression = job.cronExpression;
             }
 
             if (job.delay) {
-                toBeSaved.delay = job.delay
+                toBeSaved.delay = job.delay;
             }
 
-            return instance.Api.getApi().update(`jobConfigurations/${job.id}`, toBeSaved)
+            return instance.Api.getApi().update(`jobConfigurations/${job.id}`, toBeSaved);
         })
         .catch(error => {
             throw error;

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -4,21 +4,21 @@ import 'material-design-icons-iconfont/dist/material-design-icons.css';
 import React from 'react';
 import { Provider } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
-import '../styles/override.css';
+import { HeaderBar } from '@dhis2/ui-widgets';
+import { CssReset } from '@dhis2/ui-core';
+import { Provider as RuntimeProvider } from '@dhis2/app-runtime';
 import store from '../store';
 import MessagePanel from './MessagePanel';
 import ContentLoader from './ContentLoader';
 import AddD2Context from './AddD2Context';
-
-import { HeaderBar } from '@dhis2/ui-widgets';
-import { CssReset } from '@dhis2/ui-core';
-import { Provider as RuntimeProvider } from '@dhis2/app-runtime';
+import '../styles/override.css';
 
 const App = ({ d2, baseUrl, apiVersion }) => (
     <RuntimeProvider config={{
         baseUrl,
         apiVersion,
-    }}>
+    }}
+    >
         <Provider store={store}>
             <AddD2Context d2={d2}>
                 <div>

--- a/src/components/jobContent/AddJob.jsx
+++ b/src/components/jobContent/AddJob.jsx
@@ -32,7 +32,7 @@ const enhance = compose(
         },
     }),
     withProps(() => ({
-        saveLabel: 'Add job',
+        saveLabel: i18n.t('Add job'),
     })),
 );
 

--- a/src/components/jobContent/Content.jsx
+++ b/src/components/jobContent/Content.jsx
@@ -1,13 +1,11 @@
-import { connect } from 'react-redux'
-import MenuItem from 'material-ui/MenuItem';
+import { connect } from 'react-redux';
 import Paper from 'material-ui/Paper';
 import React, { Component } from 'react';
-import SelectField from 'material-ui/SelectField';
 import TextField from 'material-ui/TextField';
 import i18n from '@dhis2/d2-i18n';
 import moment from 'moment';
 
-import { CRON, FIXED_DELAY } from '../../constants/schedulingTypes'
+import { CRON, FIXED_DELAY } from '../../constants/schedulingTypes';
 import ActionButtons from './ActionButtons';
 import ConditionalIconButton from '../ConditionalIconButton';
 import Details from './Details';
@@ -18,7 +16,6 @@ import Parameters from '../jobParameters/Parameters';
 import Schedule from './Schedule';
 import history from '../../utils/history';
 import validCronExpression from '../../utils/validCronExpression';
-import validDelay from '../../utils/validDelay';
 
 const documentationHref =
     'https://docs.dhis2.org/master/en/user/html/dataAdmin_scheduling.html#dataAdmin_scheduling_config';
@@ -48,7 +45,7 @@ const styles = {
 
 const validateFields = (values, jobTypeToSchedulingTypes) => {
     const errors = {};
-    const { type } = values
+    const { type } = values;
 
     if (!values.name) {
         errors.name = i18n.t('Required');
@@ -69,7 +66,7 @@ const validateFields = (values, jobTypeToSchedulingTypes) => {
     }
 
     if (jobTypeToSchedulingTypes[type] === FIXED_DELAY) {
-        const { delay } = values
+        const { delay } = values;
 
         if (delay !== 0 && !delay) {
             errors.delay = i18n.t('Required');
@@ -89,7 +86,7 @@ class Content extends Component {
     state = { isValid: true, errors: {} };
 
     componentWillReceiveProps = nextProps => {
-        const { job, jobTypeToSchedulingTypes } = nextProps
+        const { job, jobTypeToSchedulingTypes } = nextProps;
         if (this.props.job !== job) {
             const errors = validateFields(job, jobTypeToSchedulingTypes);
 
@@ -124,16 +121,6 @@ class Content extends Component {
 
     handleFieldEvent = field => (event, value) => {
         this.props.editJob(field, value);
-    };
-
-    renderLastExecutionText = () => {
-        const lastExecution = moment(this.props.job.lastExecuted);
-        return (
-            <div>
-                Last executed on <b>{}</b> at <b>{lastExecution.format('HH:ss')}</b>, status:{' '}
-                {this.props.job.lastExecutedStatus}
-            </div>
-        );
     };
 
     render = () => (
@@ -233,6 +220,6 @@ const ConnectedContent = connect(
     state => ({
         jobTypeToSchedulingTypes: state.jobs.configuration.typeToSchedulingTypes,
     }),
-)(Content)
+)(Content);
 
 export default ConnectedContent;

--- a/src/components/jobContent/EditJob.jsx
+++ b/src/components/jobContent/EditJob.jsx
@@ -1,8 +1,8 @@
 import { useDispatch, useSelector } from 'react-redux';
-import React, { useEffect } from 'react'
+import React, { useEffect } from 'react';
 import i18n from '@dhis2/d2-i18n';
 
-import { CRON, FIXED_DELAY  } from '../../constants/schedulingTypes';
+import { CRON, FIXED_DELAY } from '../../constants/schedulingTypes';
 import * as actions from '../../constants/actions';
 import Loading from '../Loading';
 import Content from './Content';
@@ -12,81 +12,81 @@ import Content from './Content';
  */
 const isString = value => typeof value === 'string';
 
-const getAllJobs = state => state.jobs.all
+const getAllJobs = state => state.jobs.all;
 
-const getChanges = state => state.jobs.changes
+const getChanges = state => state.jobs.changes;
 
 const getAvailableTypes = state =>
-    state.jobs.configuration.types
+    state.jobs.configuration.types;
 
 const getTypeToSchedulingTypes = state =>
-    state.jobs.configuration.typeToSchedulingTypes
+    state.jobs.configuration.typeToSchedulingTypes;
 
 const getLoaded = state =>
-    state.jobs.loaded && state.jobs.configuration.loaded
+    state.jobs.loaded && state.jobs.configuration.loaded;
 
 const getAvailableParameters = state =>
-    state.jobs.configuration.parameters
+    state.jobs.configuration.parameters;
 
 const getAttributeOptions = state =>
-    state.jobs.configuration.attributeOptions
+    state.jobs.configuration.attributeOptions;
 
 /**
  * Hooks
  */
 const useCreateJob = (currentJob, changes) => {
-    const jobTypeToSchedulingTypes = useSelector(getTypeToSchedulingTypes)
+    const jobTypeToSchedulingTypes = useSelector(getTypeToSchedulingTypes);
 
-    if (!currentJob) return null
+    if (!currentJob) return null;
 
-    const type = changes.type || currentJob.jobType
-    const name = isString(changes.name) ? changes.name : currentJob.name
-    const parameters = changes.parameters || currentJob.jobParameters
-    const job = { ...currentJob, name, parameters, type }
+    const type = changes.type || currentJob.jobType;
+    const name = isString(changes.name) ? changes.name : currentJob.name;
+    const parameters = changes.parameters || currentJob.jobParameters;
+    const job = { ...currentJob, name, parameters, type };
 
-    const schedulingType = jobTypeToSchedulingTypes[type]
+    const schedulingType = jobTypeToSchedulingTypes[type];
 
     if (schedulingType === CRON) {
-        delete job.delay
+        delete job.delay;
         job.cronExpression = isString(changes.cronExpression)
             ? changes.cronExpression
-            : currentJob.cronExpression
+            : currentJob.cronExpression;
     } else if (schedulingType === FIXED_DELAY) {
-        delete job.cronExpression
+        delete job.cronExpression;
         job.delay = isString(changes.delay)
             ? changes.delay
-            : currentJob.delay
+            : currentJob.delay;
     }
 
-    return job
-}
+    return job;
+};
 
 /**
  * Actual component
  */
 const EditJob = ({ match }) => {
-    const dispatch = useDispatch()
-    const allJobs = useSelector(getAllJobs)
-    const changes = useSelector(getChanges)
-    const loaded = useSelector(getLoaded)
-    const availableParameters = useSelector(getAvailableParameters)
-    const attributeOptions = useSelector(getAttributeOptions)
-    const pending = useSelector(state => state.pending)
-    const dirty = useSelector(state => state.jobs.dirty)
-    const availableTypes = [ ...useSelector(getAvailableTypes) ];
+    const dispatch = useDispatch();
+    const allJobs = useSelector(getAllJobs);
+    const changes = useSelector(getChanges);
+    const loaded = useSelector(getLoaded);
+    const availableParameters = useSelector(getAvailableParameters);
+    const attributeOptions = useSelector(getAttributeOptions);
+    const pending = useSelector(state => state.pending);
+    const dirty = useSelector(state => state.jobs.dirty);
+    const availableTypes = [...useSelector(getAvailableTypes)];
 
     const currentJob = allJobs.find(({ id }) => id === match.params.id);
     const job = useCreateJob(currentJob, changes);
 
     // Hack because Mui's SelectField won't show values not in list
     if (job && availableTypes.indexOf(job.type) === -1) availableTypes.push(job.type);
-    const title = currentJob && currentJob.name
-    const disableEditing = currentJob && currentJob.configurable === false
+    const title = currentJob && currentJob.name;
+    const disableEditing = currentJob && currentJob.configurable === false;
 
     // on onmount
-    useEffect(() => () =>  dispatch({ type: actions.JOB_DISCARD }), [])
+    useEffect(() => () => dispatch({ type: actions.JOB_DISCARD }), []);
 
-    if (!loaded || !job) return <Loading />
+    if (!loaded || !job) return <Loading />;
 
     return (
         <Content
@@ -96,7 +96,7 @@ const EditJob = ({ match }) => {
             deleteLabel={i18n.t('Delete job')}
             save={() => dispatch({
                 type: actions.JOB_SAVE,
-                payload: { job: {  ...job, ...changes  } },
+                payload: { job: { ...job, ...changes } },
             })}
             delete={id => dispatch({
                 type: actions.JOB_DELETE,
@@ -114,7 +114,7 @@ const EditJob = ({ match }) => {
             title={title}
             disableEditing={disableEditing}
         />
-    )
-}
+    );
+};
 
 export default EditJob;

--- a/src/components/jobContent/JobType.jsx
+++ b/src/components/jobContent/JobType.jsx
@@ -1,14 +1,11 @@
-import { useSelector } from 'react-redux'
+import { useSelector } from 'react-redux';
 import MenuItem from 'material-ui/MenuItem';
 import React from 'react';
 import SelectField from 'material-ui/SelectField';
 import i18n from '@dhis2/d2-i18n';
 
 const getJobTypes =
-    state => state.jobs.configuration.types
-
-const getJobTypeNames =
-    state => state.jobs.configuration.jobTypeNames
+    state => state.jobs.configuration.types;
 
 const JobType = ({
     disabled,
@@ -16,8 +13,7 @@ const JobType = ({
     onChange,
     errorText,
 }) => {
-    const jobTypeNames = useSelector(getJobTypeNames)
-    const jobTypes = useSelector(getJobTypes)
+    const jobTypes = useSelector(getJobTypes);
 
     return (
         <SelectField
@@ -32,11 +28,11 @@ const JobType = ({
                 <MenuItem
                     key={type}
                     value={type}
-                    primaryText={jobTypeNames[type]}
+                    primaryText={i18n.t(type)}
                 />
             ))}
         </SelectField>
-    )
-}
+    );
+};
 
-export default JobType
+export default JobType;

--- a/src/components/jobContent/Schedule.jsx
+++ b/src/components/jobContent/Schedule.jsx
@@ -1,11 +1,11 @@
-import { useSelector } from 'react-redux'
+import { useSelector } from 'react-redux';
 import React from 'react';
 import TextField from 'material-ui/TextField';
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import i18n from '@dhis2/d2-i18n';
 import cronExpressions from '../../constants/cronExpressions';
-import { CRON, FIXED_DELAY } from '../../constants/schedulingTypes'
+import { CRON, FIXED_DELAY } from '../../constants/schedulingTypes';
 
 const styles = {
     container: {
@@ -89,28 +89,28 @@ const ScheduleDelay = ({
             value={delay || ''}
         />
     </div>
-)
+);
 
 const Schedule = props => {
-    const jobTypeToSchedulingTypes = useSelector(state => state.jobs.configuration.typeToSchedulingTypes)
-    const schedulingType = jobTypeToSchedulingTypes[props.jobType]
-    const { cronError, delayError, ...rest } = props
+    const jobTypeToSchedulingTypes = useSelector(state => state.jobs.configuration.typeToSchedulingTypes);
+    const schedulingType = jobTypeToSchedulingTypes[props.jobType];
+    const { cronError, delayError, ...rest } = props;
 
     if (schedulingType === CRON) {
-        return <ScheduleCron
+        return (<ScheduleCron
             {...rest}
             error={cronError}
-        />
+        />);
     }
 
     if (schedulingType === FIXED_DELAY) {
-        return <ScheduleDelay
+        return (<ScheduleDelay
             {...rest}
             error={delayError}
-        />
+        />);
     }
 
-    return null
-}
+    return null;
+};
 
 export default Schedule;

--- a/src/components/jobOverview/Entry.jsx
+++ b/src/components/jobOverview/Entry.jsx
@@ -67,7 +67,7 @@ const Entry = ({ job, onSelect, onToggle, onRun }) => {
         event.preventDefault();
         event.stopPropagation();
     };
-    const isCron = job.schedulingType === CRON
+    const isCron = job.schedulingType === CRON;
 
     return (
         <div onClick={onSelect} style={styles.listEntry}>

--- a/src/constants/cronExpressions.js
+++ b/src/constants/cronExpressions.js
@@ -1,10 +1,10 @@
 const cronExpressions = [
-    { text: 'Custom', value: '' },
-    { text: 'Every hour', value: '0 0 * ? * *' },
-    { text: 'Every day midnight', value: '0 0 1 ? * *' },
-    { text: 'Every day at three am', value: '0 0 3 ? * *' },
-    { text: 'Every weekday at noon', value: '0 0 12 ? * MON-FRI' },
-    { text: 'Every week', value: '0 0 3 ? * MON' },
+    { text: 'CUSTOM', value: '' },
+    { text: 'EVERY_HOUR', value: '0 0 * ? * *' },
+    { text: 'EVERY_DAY_MIDNIGHT', value: '0 0 1 ? * *' },
+    { text: 'EVERY_DAY_THREE_AM', value: '0 0 3 ? * *' },
+    { text: 'EVERY_WEEKDAY_NOON', value: '0 0 12 ? * MON-FRI' },
+    { text: 'EVERY_WEEK', value: '0 0 3 ? * MON' },
 ];
 
 export default cronExpressions;

--- a/src/constants/schedulingTypes.js
+++ b/src/constants/schedulingTypes.js
@@ -1,2 +1,2 @@
-export const CRON = 'CRON'
-export const FIXED_DELAY = 'FIXED_DELAY'
+export const CRON = 'CRON';
+export const FIXED_DELAY = 'FIXED_DELAY';

--- a/src/reducers/jobsReducer.js
+++ b/src/reducers/jobsReducer.js
@@ -1,5 +1,5 @@
 import * as actions from '../constants/actions';
-import { CRON, FIXED_DELAY } from '../constants/schedulingTypes'
+import { CRON, FIXED_DELAY } from '../constants/schedulingTypes';
 
 export const initialState = {
     all: [],
@@ -14,7 +14,6 @@ export const initialState = {
         parameters: {},
         attributeOptions: {},
         typeToSchedulingTypes: {},
-        jobTypeNames: {},
     },
     pending: {
         update: false,
@@ -40,17 +39,17 @@ function jobsReducer(state = initialState, action) {
 
         case actions.JOB_EDIT: {
             const { fieldName: field, value } = action.payload;
-            let updates = { ...state.changes }
+            const updates = { ...state.changes };
 
             if (field === 'type') {
-                const scheduleType = state.configuration.typeToSchedulingTypes[value]
+                const scheduleType = state.configuration.typeToSchedulingTypes[value];
 
                 if (scheduleType === FIXED_DELAY && updates.cronExpression) {
-                    delete updates.cronExpression
+                    delete updates.cronExpression;
                 }
 
                 if (scheduleType === CRON && updates.delay) {
-                    delete updates.delay
+                    delete updates.delay;
                 }
             }
 
@@ -74,7 +73,6 @@ function jobsReducer(state = initialState, action) {
                     statuses: action.payload.configuration.jobStatuses,
                     parameters: action.payload.configuration.jobParameters,
                     typeToSchedulingTypes: action.payload.configuration.jobTypeToSchedulingTypes,
-                    jobTypeNames: action.payload.configuration.jobTypeNames,
                 },
             };
 

--- a/src/utils/apiTranslations.js
+++ b/src/utils/apiTranslations.js
@@ -17,6 +17,7 @@ const apiTranslations = {
 
         // Job types
         ANALYTICS_TABLE: 'Analytics Table',
+        CONTINUOUS_ANALYTICS_TABLE: 'Continuous Analytics Table',
         CREDENTIALS_EXPIRY_ALERT: 'Credential Expiry Alert',
         DATA_INTEGRITY: 'Data Integrity',
         DATA_SET_NOTIFICATION: 'Data Set Notification',
@@ -37,14 +38,20 @@ const apiTranslations = {
         VALIDATION_RESULTS_NOTIFICATION: 'Validation Results Notification',
 
         // Job parameters
+        'Data values page size': 'Data values page size',
+        'Event program page size': 'Event program page size',
+        'Full update hour of day': 'Full update hour of day',
         'Last years': 'Last years',
+        'Page size': 'Page size',
         'Persist results': 'Persist results',
+        'Predictor groups': 'Predictor groups',
         'Push analysis': 'Push analysis',
         'Relative end': 'Relative end',
         'Relative start': 'Relative start',
         'Send notifications': 'Send notifications',
         'Skip resource tables': 'Skip resource tables',
         'Skip table types': 'Skip table types',
+        'Tracker program page size': 'Tracker program page size',
         'Validation rule groups': 'Validation rule groups',
         Predictors: 'Predictors',
 

--- a/src/utils/configI18n.js
+++ b/src/utils/configI18n.js
@@ -16,7 +16,7 @@ const configI18n = userSettings => {
     i18n.changeLanguage(lang);
 
     const translations = apiTranslations[lang] || apiTranslations.en;
-    i18n.addResources(lang, 'Scheduler', translations);
+    i18n.addResources(lang, 'default', translations);
 };
 
 export default configI18n;

--- a/src/utils/validDelay.js
+++ b/src/utils/validDelay.js
@@ -1,9 +1,9 @@
-const isValidInteger = value => value.match(/^\d+$/)
+const isValidInteger = value => value.match(/^\d+$/);
 
 export default delay => {
     if (!isValidInteger(delay)) {
-        return false
+        return false;
     }
 
-    return true
-}
+    return true;
+};


### PR DESCRIPTION
The translations in this app were broken in a couple of places (and I noticed my fix from earlier was incomplete). I tracked it down to [this line](https://github.com/dhis2/scheduler-app/blob/ab3cd673111847520d5464072cb04dafda3053d8/src/utils/configI18n.js#L19), where the namespace used is no longer correct (but `default` works as expected).

See [this issue](https://github.com/dhis2/app-platform/issues/369) for more info on why using the `default` namespace fixes the translations. This fix means that the translations in [apiTranslations.js](https://github.com/dhis2/scheduler-app/blob/ab3cd673111847520d5464072cb04dafda3053d8/src/utils/apiTranslations.js) are now picked up again.

Todo:

- [x] Double check all translations and hardcoded strings (there were a couple of duplicates, etc.)
- [x] Do we still need the map in redux from uppercased jobtype name to translated name?

Ref: https://jira.dhis2.org/browse/DHIS2-8709
Docs: https://www.i18next.com/principles/namespaces

As for the commits, I propose we squash them to the PR title before rebasing on master.