### PR TITLE
ci(travis): fix build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+cache:
+    npm: false
 language: node_js
 node_js:
     - lts/*


### PR DESCRIPTION
Fixes the buid failure on the refactor-scheduler branch. For some reason upgrades to our libs sometimes require you to `rm -rf node_modules && yarn`. This is a temporary fix to address that, though in the long run we should definitely make sure that our libs don't require this, because it's affecting the reliability/reproducibility of our dependency installations.