### PR TITLE
fix(update-job-hook): use PUT for job configuration update

### DIFF
--- a/src/hooks/jobs/use-update-job.js
+++ b/src/hooks/jobs/use-update-job.js
@@ -2,14 +2,9 @@ import { useDataEngine } from '@dhis2/app-runtime'
 import history from '../../services/history'
 import formatError from '../../services/format-error'
 
-/**
- * A partial mutation, or PATCH, because PUT isn't allowed for this endpoint
- */
-
 const mutation = {
     resource: 'jobConfigurations',
     type: 'update',
-    partial: true,
     id: /* istanbul ignore next */ ({ id }) => id,
     data: /* istanbul ignore next */ ({ job }) => job,
 }


### PR DESCRIPTION
In going through the [docs](https://docs.dhis2.org/master/en/developer/html/webapi_scheduling.html) for the Jira epic I'm currently updating, I noticed that the docs mention that an update of a job should be possible with a PUT.

I know that in the past I encountered a bug there, and updating only worked with PATCH, but now that I've tested again it seems to be working just fine. Since this is what the docs recommend, I've changed this hook to use the recommended approach.