### PR TITLE
fix: job run throwing error for successful job

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -147,7 +147,7 @@ export const runJob = id =>
     getD2Instance()
         .then(instance => instance.Api.getApi().get(`jobConfigurations/${id}/execute`))
         .then(result => {
-            if (result.errorReports) {
+            if (result.errorReports && result.errorReports.length > 0) {
                 throw result;
             }
         })


### PR DESCRIPTION
With a successful job we're getting an empty array, which caused the line I've changed to throw. By checking whether there are actually any errors it now only throws if we're getting errorreports.

Closes #56

Note: don't merge until we've got approval from the release board.