### PR TITLE
fix: only throw job run error if there are error reports

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -147,7 +147,7 @@ export const runJob = id =>
     getD2Instance()
         .then(instance => instance.Api.getApi().get(`jobConfigurations/${id}/execute`))
         .then(result => {
-            if (result.errorReports) {
+            if (result.errorReports && result.errorReports.length > 0) {
                 throw result;
             }
         })


### PR DESCRIPTION
Closes #56

See: https://github.com/dhis2/scheduler-app/pull/57