### PR TITLE
fix(job-form): fix parameter header

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-07-22T08:26:40.694Z\n"
-"PO-Revision-Date: 2020-07-22T08:26:40.694Z\n"
+"POT-Creation-Date: 2021-01-13T13:57:54.508Z\n"
+"PO-Revision-Date: 2021-01-13T13:57:54.508Z\n"
 
 msgid "Checking permissions"
 msgstr ""
@@ -39,6 +39,9 @@ msgid "Job type"
 msgstr ""
 
 msgid "No options available"
+msgstr ""
+
+msgid "Parameters"
 msgstr ""
 
 msgid "Save"

--- a/src/components/FormFields/ParameterFields.js
+++ b/src/components/FormFields/ParameterFields.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import i18n from '@dhis2/d2-i18n'
 import { PropTypes } from '@dhis2/prop-types'
 import { ReactFinalForm, InputFieldFF, SwitchFieldFF, Box } from '@dhis2/ui'
 import { useDataQuery } from '@dhis2/app-runtime'
@@ -114,7 +115,7 @@ const ParameterFields = ({ jobType }) => {
     return (
         <React.Fragment>
             <header>
-                <h4 className={styles.headerTitle}>Monitoring parameters</h4>
+                <h4 className={styles.headerTitle}>{i18n.t('Parameters')}</h4>
             </header>
             {parameterComponents}
         </React.Fragment>


### PR DESCRIPTION
I accidentally took the header verbatim from the design, but `Monitoring` shouldn't be part of the header, so I simplified it to just `Parameters`, so that it applies everywhere.