### PR TITLE
refactor(jobtable): extract job table from joblist route for clarity

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-01-26T16:54:51.475Z\n"
-"PO-Revision-Date: 2021-01-26T16:54:51.475Z\n"
+"POT-Creation-Date: 2021-01-27T14:53:43.626Z\n"
+"PO-Revision-Date: 2021-01-27T14:53:43.626Z\n"
 
 msgid "Not authorized"
 msgstr ""
@@ -67,6 +67,45 @@ msgstr ""
 msgid "Last run status: {{ translatedStatus }}."
 msgstr ""
 
+msgid "Actions"
+msgstr ""
+
+msgid "Delete"
+msgstr ""
+
+msgid "Edit"
+msgstr ""
+
+msgid "Job name"
+msgstr ""
+
+msgid "Type"
+msgstr ""
+
+msgid "Schedule"
+msgstr ""
+
+msgid "Next run"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "On/off"
+msgstr ""
+
+msgid "No jobs to display"
+msgstr ""
+
+msgid "Not scheduled"
+msgstr ""
+
+msgid "Run manually"
+msgstr ""
+
+msgid "{{ delay }} seconds after last run"
+msgstr ""
+
 msgid "Every hour"
 msgstr ""
 
@@ -89,9 +128,6 @@ msgid "Insert preset"
 msgstr ""
 
 msgid "Are you sure you want to delete this job?"
-msgstr ""
-
-msgid "Delete"
 msgstr ""
 
 msgid "Are you sure you want to discard this form?"
@@ -121,9 +157,6 @@ msgstr ""
 msgid "Job: {{ name }}"
 msgstr ""
 
-msgid "Edit"
-msgstr ""
-
 msgid "Scheduled jobs"
 msgstr ""
 
@@ -134,39 +167,6 @@ msgid "Show system jobs"
 msgstr ""
 
 msgid "New job"
-msgstr ""
-
-msgid "Actions"
-msgstr ""
-
-msgid "Job name"
-msgstr ""
-
-msgid "Type"
-msgstr ""
-
-msgid "Schedule"
-msgstr ""
-
-msgid "Next run"
-msgstr ""
-
-msgid "Status"
-msgstr ""
-
-msgid "On/off"
-msgstr ""
-
-msgid "No jobs to display"
-msgstr ""
-
-msgid "Not scheduled"
-msgstr ""
-
-msgid "{{ delay }} seconds after last run"
-msgstr ""
-
-msgid "Run manually"
 msgstr ""
 
 msgid "Data value"

--- a/src/components/JobTable/Actions.js
+++ b/src/components/JobTable/Actions.js
@@ -2,18 +2,18 @@ import React from 'react'
 import { PropTypes } from '@dhis2/prop-types'
 import { FlyoutMenu, DropdownButton } from '@dhis2/ui'
 import i18n from '@dhis2/d2-i18n'
-import EditJobMenuItem from './EditJobMenuItem'
-import RunJobMenuItem from './RunJobMenuItem'
-import DeleteJobMenuItem from './DeleteJobMenuItem'
+import EditJobAction from './EditJobAction'
+import RunJobAction from './RunJobAction'
+import DeleteJobAction from './DeleteJobAction'
 
-const JobListActions = ({ id, configurable }) => (
+const Actions = ({ id, configurable }) => (
     <DropdownButton
         small
         component={
             <FlyoutMenu>
-                {configurable && <EditJobMenuItem id={id} />}
-                <RunJobMenuItem id={id} />
-                <DeleteJobMenuItem id={id} />
+                {configurable && <EditJobAction id={id} />}
+                <RunJobAction id={id} />
+                <DeleteJobAction id={id} />
             </FlyoutMenu>
         }
     >
@@ -21,15 +21,15 @@ const JobListActions = ({ id, configurable }) => (
     </DropdownButton>
 )
 
-JobListActions.defaultProps = {
+Actions.defaultProps = {
     configurable: false,
 }
 
 const { string, bool } = PropTypes
 
-JobListActions.propTypes = {
+Actions.propTypes = {
     id: string.isRequired,
     configurable: bool,
 }
 
-export default JobListActions
+export default Actions

--- a/src/components/JobTable/Actions.test.js
+++ b/src/components/JobTable/Actions.test.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import JobListActions from './JobListActions'
+import Actions from './Actions'
 
-describe('<JobListActions>', () => {
+describe('<Actions>', () => {
     it('renders without errors for configurable jobs', () => {
-        shallow(<JobListActions id="1" configurable />)
+        shallow(<Actions id="1" configurable />)
     })
 
     it('renders without errors for non configurable jobs', () => {
-        shallow(<JobListActions id="1" />)
+        shallow(<Actions id="1" />)
     })
 })

--- a/src/components/JobTable/DeleteJobAction.js
+++ b/src/components/JobTable/DeleteJobAction.js
@@ -2,10 +2,10 @@ import React, { useState, useContext } from 'react'
 import { PropTypes } from '@dhis2/prop-types'
 import { MenuItem } from '@dhis2/ui'
 import i18n from '@dhis2/d2-i18n'
-import { DeleteJobModal } from '../../components/Modal'
-import { RefetchJobsContext } from '../../components/Context'
+import { DeleteJobModal } from '../Modal'
+import { RefetchJobsContext } from '../Context'
 
-const DeleteJobMenuItem = ({ id }) => {
+const DeleteJobAction = ({ id }) => {
     const [showModal, setShowModal] = useState(false)
     const refetch = useContext(RefetchJobsContext)
 
@@ -35,8 +35,8 @@ const DeleteJobMenuItem = ({ id }) => {
 
 const { string } = PropTypes
 
-DeleteJobMenuItem.propTypes = {
+DeleteJobAction.propTypes = {
     id: string.isRequired,
 }
 
-export default DeleteJobMenuItem
+export default DeleteJobAction

--- a/src/components/JobTable/DeleteJobAction.test.js
+++ b/src/components/JobTable/DeleteJobAction.test.js
@@ -1,14 +1,14 @@
 import React from 'react'
 import { shallow, mount } from 'enzyme'
-import DeleteJobMenuItem from './DeleteJobMenuItem'
+import DeleteJobAction from './DeleteJobAction'
 
-describe('<DeleteJobMenuItem>', () => {
+describe('<DeleteJobAction>', () => {
     it('renders without errors', () => {
-        shallow(<DeleteJobMenuItem id="id" />)
+        shallow(<DeleteJobAction id="id" />)
     })
 
     it('shows the modal when MenuItem is clicked', () => {
-        const wrapper = mount(<DeleteJobMenuItem id="id" />)
+        const wrapper = mount(<DeleteJobAction id="id" />)
 
         expect(wrapper.find('DeleteJobModal')).toHaveLength(0)
 

--- a/src/components/JobTable/EditJobAction.js
+++ b/src/components/JobTable/EditJobAction.js
@@ -4,7 +4,7 @@ import { MenuItem } from '@dhis2/ui'
 import i18n from '@dhis2/d2-i18n'
 import history from '../../services/history'
 
-const EditJobMenuItem = ({ id }) => (
+const EditJobAction = ({ id }) => (
     <MenuItem
         dense
         onClick={() => history.push(`/edit/${id}`)}
@@ -14,8 +14,8 @@ const EditJobMenuItem = ({ id }) => (
 
 const { string } = PropTypes
 
-EditJobMenuItem.propTypes = {
+EditJobAction.propTypes = {
     id: string.isRequired,
 }
 
-export default EditJobMenuItem
+export default EditJobAction

--- a/src/components/JobTable/EditJobAction.test.js
+++ b/src/components/JobTable/EditJobAction.test.js
@@ -1,19 +1,19 @@
 import React from 'react'
 import { shallow, mount } from 'enzyme'
 import history from '../../services/history'
-import EditJobMenuItem from './EditJobMenuItem'
+import EditJobAction from './EditJobAction'
 
 jest.mock('../../services/history', () => ({
     push: jest.fn(),
 }))
 
-describe('<EditJobMenuItem>', () => {
+describe('<EditJobAction>', () => {
     it('renders without errors', () => {
-        shallow(<EditJobMenuItem id="id" />)
+        shallow(<EditJobAction id="id" />)
     })
 
     it('calls history.push correctly when MenuItem is clicked', () => {
-        const wrapper = mount(<EditJobMenuItem id="id" />)
+        const wrapper = mount(<EditJobAction id="id" />)
 
         wrapper.find('a').simulate('click')
 

--- a/src/components/JobTable/JobTable.js
+++ b/src/components/JobTable/JobTable.js
@@ -10,9 +10,9 @@ import {
     TableBody,
 } from '@dhis2/ui'
 import i18n from '@dhis2/d2-i18n'
-import JobListTableItem from './JobListTableItem'
+import JobTableRow from './JobTableRow'
 
-const JobListTable = ({ jobIds, jobEntities }) => (
+const JobTable = ({ jobIds, jobEntities }) => (
     <Table>
         <TableHead>
             <TableRowHead>
@@ -31,9 +31,7 @@ const JobListTable = ({ jobIds, jobEntities }) => (
                     <TableCell>{i18n.t('No jobs to display')}</TableCell>
                 </TableRow>
             ) : (
-                jobIds.map(id => (
-                    <JobListTableItem key={id} job={jobEntities[id]} />
-                ))
+                jobIds.map(id => <JobTableRow key={id} job={jobEntities[id]} />)
             )}
         </TableBody>
     </Table>
@@ -41,9 +39,9 @@ const JobListTable = ({ jobIds, jobEntities }) => (
 
 const { object, arrayOf, string } = PropTypes
 
-JobListTable.propTypes = {
+JobTable.propTypes = {
     jobEntities: object.isRequired,
     jobIds: arrayOf(string).isRequired,
 }
 
-export default JobListTable
+export default JobTable

--- a/src/components/JobTable/JobTable.test.js
+++ b/src/components/JobTable/JobTable.test.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import JobListTable from './JobListTable'
+import JobTable from './JobTable'
 
-describe('<JobListTable>', () => {
+describe('<JobTable>', () => {
     it('renders without errors when there are jobs', () => {
         const jobIds = ['1', '2']
         const jobEntities = {
@@ -28,13 +28,13 @@ describe('<JobListTable>', () => {
             },
         }
 
-        shallow(<JobListTable jobIds={jobIds} jobEntities={jobEntities} />)
+        shallow(<JobTable jobIds={jobIds} jobEntities={jobEntities} />)
     })
 
     it('renders without errors when there are no jobs', () => {
         const jobIds = []
         const jobEntities = {}
 
-        shallow(<JobListTable jobIds={jobIds} jobEntities={jobEntities} />)
+        shallow(<JobTable jobIds={jobIds} jobEntities={jobEntities} />)
     })
 })

--- a/src/components/JobTable/JobTableRow.js
+++ b/src/components/JobTable/JobTableRow.js
@@ -2,13 +2,13 @@ import React from 'react'
 import { PropTypes } from '@dhis2/prop-types'
 import { TableRow, TableCell } from '@dhis2/ui'
 import { jobTypesMap } from '../../services/server-translations'
-import { ToggleJobSwitch } from '../../components/Switches'
-import JobListActions from './JobListActions'
-import JobStatus from './JobStatus'
-import JobNextRun from './JobNextRun'
-import JobSchedule from './JobSchedule'
+import { ToggleJobSwitch } from '../Switches'
+import Actions from './Actions'
+import Status from './Status'
+import NextRun from './NextRun'
+import Schedule from './Schedule'
 
-const JobListTableItem = ({
+const JobTableRow = ({
     job: {
         id,
         displayName,
@@ -26,33 +26,30 @@ const JobListTableItem = ({
         <TableCell>{displayName}</TableCell>
         <TableCell>{jobTypesMap[jobType]}</TableCell>
         <TableCell>
-            <JobSchedule
+            <Schedule
                 cronExpression={cronExpression}
                 delay={delay}
                 schedulingType={schedulingType}
             />
         </TableCell>
         <TableCell>
-            <JobNextRun
-                nextExecutionTime={nextExecutionTime}
-                enabled={enabled}
-            />
+            <NextRun nextExecutionTime={nextExecutionTime} enabled={enabled} />
         </TableCell>
         <TableCell>
-            <JobStatus status={jobStatus} />
+            <Status status={jobStatus} />
         </TableCell>
         <TableCell>
             <ToggleJobSwitch id={id} checked={enabled} />
         </TableCell>
         <TableCell>
-            <JobListActions id={id} configurable={configurable} />
+            <Actions id={id} configurable={configurable} />
         </TableCell>
     </TableRow>
 )
 
 const { shape, string, bool, number } = PropTypes
 
-JobListTableItem.propTypes = {
+JobTableRow.propTypes = {
     job: shape({
         displayName: string.isRequired,
         enabled: bool.isRequired,
@@ -66,4 +63,4 @@ JobListTableItem.propTypes = {
     }).isRequired,
 }
 
-export default JobListTableItem
+export default JobTableRow

--- a/src/components/JobTable/JobTableRow.test.js
+++ b/src/components/JobTable/JobTableRow.test.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import JobListTableItem from './JobListTableItem'
+import JobTableRow from './JobTableRow'
 
-describe('<JobListTableItem>', () => {
+describe('<JobTableRow>', () => {
     it('renders cron jobs without errors', () => {
         const job = {
             id: '1',
@@ -16,7 +16,7 @@ describe('<JobListTableItem>', () => {
             configurable: true,
         }
 
-        shallow(<JobListTableItem job={job} />)
+        shallow(<JobTableRow job={job} />)
     })
 
     it('renders fixed delay jobs without errors', () => {
@@ -32,6 +32,6 @@ describe('<JobListTableItem>', () => {
             configurable: true,
         }
 
-        shallow(<JobListTableItem job={job} />)
+        shallow(<JobTableRow job={job} />)
     })
 })

--- a/src/components/JobTable/NextRun.js
+++ b/src/components/JobTable/NextRun.js
@@ -2,7 +2,7 @@ import moment from 'moment'
 import { PropTypes } from '@dhis2/prop-types'
 import i18n from '@dhis2/d2-i18n'
 
-const JobNextRun = ({ nextExecutionTime, enabled }) => {
+const NextRun = ({ nextExecutionTime, enabled }) => {
     if (!enabled || !nextExecutionTime) {
         return '-'
     }
@@ -32,9 +32,9 @@ const JobNextRun = ({ nextExecutionTime, enabled }) => {
 
 const { bool, string } = PropTypes
 
-JobNextRun.propTypes = {
+NextRun.propTypes = {
     enabled: bool.isRequired,
     nextExecutionTime: string,
 }
 
-export default JobNextRun
+export default NextRun

--- a/src/components/JobTable/NextRun.test.js
+++ b/src/components/JobTable/NextRun.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import JobNextRun from './JobNextRun'
+import NextRun from './NextRun'
 
 // Z is the zone designator for the zero UTC offset
 const now = new Date('2010-10-10T10:10:10.000Z').valueOf()
@@ -9,13 +9,13 @@ const now = new Date('2010-10-10T10:10:10.000Z').valueOf()
 const past = '2009-10-10T10:10:10.000'
 const future = '2011-10-10T10:10:10.000'
 
-describe('<JobNextRun>', () => {
+describe('<NextRun>', () => {
     it('returns the next run time for an enabled job and a future execution time', () => {
         const expected = 'in a year'
         jest.spyOn(global.Date, 'now').mockImplementation(() => now)
 
         const wrapper = shallow(
-            <JobNextRun nextExecutionTime={future} enabled={true} />
+            <NextRun nextExecutionTime={future} enabled={true} />
         )
 
         expect(wrapper.text()).toEqual(expect.stringMatching(expected))
@@ -26,7 +26,7 @@ describe('<JobNextRun>', () => {
         jest.spyOn(global.Date, 'now').mockImplementation(() => now)
 
         const wrapper = shallow(
-            <JobNextRun nextExecutionTime={past} enabled={true} />
+            <NextRun nextExecutionTime={past} enabled={true} />
         )
 
         expect(wrapper.text()).toEqual(expect.stringMatching(expected))
@@ -37,7 +37,7 @@ describe('<JobNextRun>', () => {
         jest.spyOn(global.Date, 'now').mockImplementation(() => now)
 
         const wrapper = shallow(
-            <JobNextRun nextExecutionTime={''} enabled={false} />
+            <NextRun nextExecutionTime={''} enabled={false} />
         )
 
         expect(wrapper.text()).toEqual(expect.stringMatching(expected))

--- a/src/components/JobTable/RunJobAction.js
+++ b/src/components/JobTable/RunJobAction.js
@@ -2,9 +2,9 @@ import React, { useState } from 'react'
 import { PropTypes } from '@dhis2/prop-types'
 import { MenuItem } from '@dhis2/ui'
 import i18n from '@dhis2/d2-i18n'
-import { RunJobModal } from '../../components/Modal'
+import { RunJobModal } from '../Modal'
 
-const RunJobMenuItem = ({ id }) => {
+const RunJobAction = ({ id }) => {
     const [showModal, setShowModal] = useState(false)
 
     return (
@@ -31,8 +31,8 @@ const RunJobMenuItem = ({ id }) => {
 
 const { string } = PropTypes
 
-RunJobMenuItem.propTypes = {
+RunJobAction.propTypes = {
     id: string.isRequired,
 }
 
-export default RunJobMenuItem
+export default RunJobAction

--- a/src/components/JobTable/RunJobAction.test.js
+++ b/src/components/JobTable/RunJobAction.test.js
@@ -1,14 +1,14 @@
 import React from 'react'
 import { shallow, mount } from 'enzyme'
-import RunJobMenuItem from './RunJobMenuItem'
+import RunJobAction from './RunJobAction'
 
-describe('<RunJobMenuItem>', () => {
+describe('<RunJobAction>', () => {
     it('renders without errors', () => {
-        shallow(<RunJobMenuItem id="id" />)
+        shallow(<RunJobAction id="id" />)
     })
 
     it('shows the modal when MenuItem is clicked', () => {
-        const wrapper = mount(<RunJobMenuItem id="id" />)
+        const wrapper = mount(<RunJobAction id="id" />)
 
         expect(wrapper.find('RunJobModal')).toHaveLength(0)
 

--- a/src/components/JobTable/Schedule.js
+++ b/src/components/JobTable/Schedule.js
@@ -2,7 +2,7 @@ import { PropTypes } from '@dhis2/prop-types'
 import i18n from '@dhis2/d2-i18n'
 import translateCron from '../../services/translate-cron'
 
-const JobSchedule = ({ cronExpression, schedulingType, delay }) => {
+const Schedule = ({ cronExpression, schedulingType, delay }) => {
     switch (schedulingType) {
         case 'CRON':
             return translateCron(cronExpression)
@@ -16,10 +16,10 @@ const JobSchedule = ({ cronExpression, schedulingType, delay }) => {
 
 const { string, number } = PropTypes
 
-JobSchedule.propTypes = {
+Schedule.propTypes = {
     schedulingType: string.isRequired,
     cronExpression: string,
     delay: number,
 }
 
-export default JobSchedule
+export default Schedule

--- a/src/components/JobTable/Schedule.test.js
+++ b/src/components/JobTable/Schedule.test.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import JobSchedule from './JobSchedule'
+import Schedule from './Schedule'
 
-describe('<JobSchedule>', () => {
+describe('<Schedule>', () => {
     it('renders a human readable cron for the CRON scheduling type', () => {
         const wrapper = shallow(
-            <JobSchedule schedulingType="CRON" cronExpression="0 0 1 ? * *" />
+            <Schedule schedulingType="CRON" cronExpression="0 0 1 ? * *" />
         )
 
         expect(wrapper.text()).toEqual(expect.stringContaining('At 01:00 AM'))
@@ -13,7 +13,7 @@ describe('<JobSchedule>', () => {
 
     it('renders a delay for the FIXED_DELAY scheduling type', () => {
         const wrapper = shallow(
-            <JobSchedule schedulingType="FIXED_DELAY" delay={1000} />
+            <Schedule schedulingType="FIXED_DELAY" delay={1000} />
         )
 
         expect(wrapper.text()).toEqual(
@@ -22,7 +22,7 @@ describe('<JobSchedule>', () => {
     })
 
     it('renders a dash for an unrecognised scheduling type', () => {
-        const wrapper = shallow(<JobSchedule schedulingType="NONEXISTENT" />)
+        const wrapper = shallow(<Schedule schedulingType="NONEXISTENT" />)
 
         expect(wrapper.text()).toEqual(expect.stringContaining('-'))
     })

--- a/src/components/JobTable/Status.js
+++ b/src/components/JobTable/Status.js
@@ -3,7 +3,7 @@ import { PropTypes } from '@dhis2/prop-types'
 import { Tag } from '@dhis2/ui'
 import { jobStatusMap } from '../../services/server-translations'
 
-const JobStatus = ({ status }) => {
+const Status = ({ status }) => {
     switch (status) {
         case 'STOPPED':
         case 'DISABLED':
@@ -24,8 +24,8 @@ const JobStatus = ({ status }) => {
 
 const { string } = PropTypes
 
-JobStatus.propTypes = {
+Status.propTypes = {
     status: string.isRequired,
 }
 
-export default JobStatus
+export default Status

--- a/src/components/JobTable/Status.test.js
+++ b/src/components/JobTable/Status.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import JobStatus from './JobStatus'
+import Status from './Status'
 
 const statuses = [
     'STOPPED',
@@ -12,13 +12,13 @@ const statuses = [
     'DONE',
 ]
 
-describe('<JobStatus>', () => {
+describe('<Status>', () => {
     it.each(statuses)('renders without errors for %s status', status => {
-        shallow(<JobStatus status={status} />)
+        shallow(<Status status={status} />)
     })
 
     it('returns null for an invalid status', () => {
-        const wrapper = shallow(<JobStatus status="INVALID" />)
+        const wrapper = shallow(<Status status="INVALID" />)
 
         expect(wrapper.isEmptyRender()).toBe(true)
     })

--- a/src/components/JobTable/index.js
+++ b/src/components/JobTable/index.js
@@ -1,0 +1,3 @@
+import JobTable from './JobTable'
+
+export { JobTable }

--- a/src/pages/JobList/JobList.js
+++ b/src/pages/JobList/JobList.js
@@ -3,7 +3,7 @@ import { PropTypes } from '@dhis2/prop-types'
 import { Card, Switch, Input, Button, IconInfo16 } from '@dhis2/ui'
 import i18n from '@dhis2/d2-i18n'
 import history from '../../services/history'
-import JobListTable from './JobListTable'
+import { JobTable } from '../../components/JobTable'
 import styles from './JobList.module.css'
 
 const infoLink =
@@ -66,7 +66,7 @@ const JobList = ({
                         </Button>
                     </div>
                 </div>
-                <JobListTable jobIds={jobIds} jobEntities={jobEntities} />
+                <JobTable jobIds={jobIds} jobEntities={jobEntities} />
             </Card>
         </React.Fragment>
     )

--- a/src/pages/JobList/JobList.test.js
+++ b/src/pages/JobList/JobList.test.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme'
 import history from '../../services/history'
 import JobList from './JobList'
 
-jest.mock('./JobListTable', () => () => null)
+jest.mock('../../components/JobTable', () => ({ JobTable: () => null }))
 
 jest.mock('../../services/history', () => ({
     push: jest.fn(),


### PR DESCRIPTION
I've extracted the job table from the job list route. All the job table components cluttered up the job list route and made it harder to work on. Since the job table is a piece of functionality that seems quite self contained, I've moved it to its own folder.