### PR TITLE
fix(editform): replace query with store

### DIFF
--- a/src/components/Forms/JobEditFormContainer.test.js
+++ b/src/components/Forms/JobEditFormContainer.test.js
@@ -1,16 +1,10 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { useDataQuery } from '@dhis2/app-runtime'
-import expectRenderError from '../../../test/expect-render-error'
+import { StoreContext } from '../Store'
 import JobEditFormContainer from './JobEditFormContainer'
 
 jest.mock('react-router-dom', () => ({
     useParams: () => ({ id: 'id' }),
-}))
-
-jest.mock('@dhis2/app-runtime', () => ({
-    useDataQuery: jest.fn(),
-    useDataEngine: () => {},
 }))
 
 afterEach(() => {
@@ -18,44 +12,15 @@ afterEach(() => {
 })
 
 describe('<JobEditFormContainer>', () => {
-    it('returns null when loading', () => {
-        useDataQuery.mockImplementation(() => ({
-            loading: true,
-        }))
-        const props = {
-            setIsPristine: () => {},
+    it('renders without errors', () => {
+        const store = {
+            jobs: { id: 'id' },
         }
 
-        const wrapper = shallow(<JobEditFormContainer {...props} />)
-
-        expect(wrapper.isEmptyRender()).toBe(true)
-    })
-
-    it('throws errors it encounters during fetching', () => {
-        const message = 'Something went wrong'
-        const props = {
-            setIsPristine: () => {},
-        }
-
-        useDataQuery.mockImplementation(() => ({
-            loading: false,
-            error: new Error(message),
-            data: null,
-        }))
-
-        expectRenderError(<JobEditFormContainer {...props} />, message)
-    })
-
-    it('renders without errors if there is data', () => {
-        useDataQuery.mockImplementation(() => ({
-            loading: true,
-            error: undefined,
-            data: { job: {} },
-        }))
-        const props = {
-            setIsPristine: () => {},
-        }
-
-        shallow(<JobEditFormContainer {...props} />)
+        shallow(
+            <StoreContext.Provider value={store}>
+                <JobEditFormContainer setIsPristine={() => {}} />
+            </StoreContext.Provider>
+        )
     })
 })


### PR DESCRIPTION
I missed a query when moving everything to the store. This takes care of the last remaining dataquery.