### PR TITLE
fix(view-route): use hooks instead of selectors

### DIFF
--- a/src/pages/JobView/JobView.js
+++ b/src/pages/JobView/JobView.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import { useParams } from 'react-router-dom'
 import {
     Card,
@@ -9,7 +9,7 @@ import {
     InputField,
 } from '@dhis2/ui'
 import i18n from '@dhis2/d2-i18n'
-import { StoreContext, selectors } from '../../components/Store'
+import { hooks } from '../../components/Store'
 import { DiscardFormButton } from '../../components/Buttons'
 import { JobDetails } from '../../components/JobDetails'
 import translateCron from '../../services/translate-cron'
@@ -20,7 +20,6 @@ const infoLink =
     'https://docs.dhis2.org/master/en/user/html/dataAdmin_scheduling.html#dataAdmin_scheduling_config'
 
 const JobView = () => {
-    const store = useContext(StoreContext)
     const { id } = useParams()
     const {
         name,
@@ -29,7 +28,7 @@ const JobView = () => {
         lastExecuted,
         jobType,
         cronExpression,
-    } = selectors.getJobById(store, id)
+    } = hooks.useJob(id)
 
     return (
         <React.Fragment>


### PR DESCRIPTION
Lesson learned. What went wrong is that I trusted the GH ui too much. It said I could merge without conflicts, but actually, 80 and 81 were not rebased on master. So even though we could merge without conflicts, it did create a part of the app that relied on code that was removed in 80 & 81. So always rebase on master, or run tests and linting on the resulting code after the merge as well.