### PR TITLE
fix(translations): use default namespace for translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "postbuild": "npm run manifest",
         "manifest": "d2-manifest package.json build/manifest.webapp",
         "format": "prettier --write \"src/**/*.j{s,sx}\"",
-        "localize": "npm run extract-pot && d2-i18n-generate -n Scheduler -p ./i18n/ -o ./src/locales/",
+        "localize": "npm run extract-pot && d2-i18n-generate -n default -p ./i18n/ -o ./src/locales/",
         "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
         "prestart": "npm run localize && d2-manifest package.json ./public/manifest.webapp"
     },

--- a/src/utils/configI18n.js
+++ b/src/utils/configI18n.js
@@ -16,7 +16,7 @@ const configI18n = userSettings => {
     i18n.changeLanguage(lang);
 
     const translations = apiTranslations[lang] || apiTranslations.en;
-    i18n.addResources(lang, 'Scheduler', translations);
+    i18n.addResources(lang, 'default', translations);
 };
 
 export default configI18n;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5890,7 +5890,7 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
   dependencies:
     minimist "0.0.8"
 
-moment@2.29.1, moment@^2.22.1, moment@^2.24.0:
+moment@^2.22.1, moment@^2.24.0, moment@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-10635

Setting the namespace to default for v33, v34 and v35. It was causing issues on some branches. This way it's consistent everywhere.