### PR TITLE
ci(dependabot): fix dependabot prs failing due to missing token

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -12,10 +12,22 @@ env:
     D2_VERBOSE: true
 
 jobs:
+    tokens:
+        runs-on: ubuntu-latest
+        outputs:
+            has_gh_token: ${{ steps.check_gh_token.outputs.has_token }}
+        steps:
+            - id: check_gh_token
+              run: |
+                  if ! [[ -z "${{ env.FAKE_TOKEN }}" ]]; then
+                    echo "::set-output name=has_token::true"
+                  else
+                    echo "::set-output name=has_token::false"
+                  fi
+
     install:
         runs-on: ubuntu-latest
         if: "!contains(github.event.head_commit.message, '[skip ci]')"
-
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
@@ -152,8 +164,8 @@ jobs:
 
     publish:
         runs-on: ubuntu-latest
-        needs: [build, lint, test] # add e2e if you use it
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
+        needs: [tokens, build, lint, test] # add e2e if you use it
+        if: "${{ needs.tokens.outputs.has_gh_token }} == 'true' && !contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2
               with:
@@ -176,8 +188,8 @@ jobs:
 
     release:
         runs-on: ubuntu-latest
-        needs: [publish]
-        if: "github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip ci]')"
+        needs: [tokens, publish]
+        if: "${{ needs.tokens.outputs.has_gh_token }} == 'true' && github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2
               with:


### PR DESCRIPTION
I'm testing a fix that prevents dependabot PRs from failing. Basically skipping steps that require a GH_TOKEN when there isn't one available. It's based on the way it's done here:

https://github.com/google/gvisor/commit/315c167de2acddeef90b2a4765c9736e35523129#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9f

However, I've adapted it slightly, to match this approach:

 https://medium.com/@blakenewman/hey-no-problem-actually-github-has-made-an-alternative-way-to-achieve-this-possible-and-is-a-bit-e08bd574f6c6

so that we can share the check across jobs. I've put in an env var in the check that does not exist (which we can later substitute for GH_TOKEN), to test it. Github actions should now skip the `publish` and `release` step since that var doesn't exist. However, it doesn't. I'm not sure if I'm overlooking something obvious here. Any ideas @varl?

See also:

- https://github.community/t/if-expression-with-context-variable/16558/6
- https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idoutputs