### PR TITLE
ci(yarn): optimize yarn installation steps

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -22,14 +22,18 @@ jobs:
               with:
                   node-version: 12.x
 
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+
             - uses: actions/cache@v2
-              id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
               with:
-                  path: '**/node_modules'
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
 
             - name: Install
-              if: steps.yarn-cache.outputs.cache-hit != 'true'
               run: yarn install --frozen-lockfile --ignore-scripts
 
     build:

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -30,7 +30,7 @@ jobs:
 
             - name: Install
               if: steps.yarn-cache.outputs.cache-hit != 'true'
-              run: yarn install --frozen-lockfile
+              run: yarn install --frozen-lockfile --ignore-scripts
 
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Replicating an `npm ci` type install with yarn by caching the yarn cache dir and installing node_modules from scratch (instead of caching node_modules). See also: https://github.com/actions/cache/blob/main/examples.md#node---yarn. I've also skipped scripts as we shouldn't need them on CI.

For further optimization maybe we could:

- Cache node_modules after this type of fresh install and restore those only if the yarn.lock is an exact match.
- Also, the yarn cache could be shared with other jobs, even if yarn.lock isn't an exact match. Yarn will only take from the cache what it needs anyway, so it isn't as bad if it's not an exact match.

This PR is on hold until https://github.com/dhis2/scheduler-app/pull/169 has been resolved. After that I'll rebase this branch.