### PR TITLE
ci(cypress): add a unique cypress id for each e2e run

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -105,50 +105,60 @@ jobs:
             - name: Test
               run: yarn test
 
-    #e2e:
-    #    runs-on: ubuntu-latest
-    #    if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    #    needs: [install]
-    #
-    #    strategy:
-    #        matrix:
-    #            containers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    #
-    #    steps:
-    #        - name: Checkout
-    #          uses: actions/checkout@v2
-    #
-    #        - uses: actions/setup-node@v1
-    #          with:
-    #              node-version: 12.x
-    #
-    #        - uses: actions/cache@v2
-    #          id: yarn-cache
-    #          with:
-    #              path: '**/node_modules'
-    #              key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-    #
-    #        - name: Install Cypress binary
-    #          run: yarn cypress install
-    #
-    #        - name: End-to-End tests
-    #          uses: cypress-io/github-action@v2
-    #          with:
-    #              install: false
-    #              record: true
-    #              parallel: true
-    #              start: ${{ env.SERVER_START_CMD }}
-    #              wait-on: ${{ env.SERVER_URL }}
-    #              wait-on-timeout: 300
-    #              cache-key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-    #              group: 'e2e'
-    #              tag: ${{ github.event_name }}
-    #          env:
-    #              CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-    #              COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
-    #              STORYBOOK_TESTING: true
-    #              SERVER_START_CMD: 'yarn cy:server'
-    #              SERVER_URL: 'http://localhost:5001'
+    cypress_id:
+        runs-on: ubuntu-latest
+        outputs:
+            ci_build_id: ${{ steps.ci_build_id.outputs.value }}
+
+        steps:
+            - name: Generate cypress build id
+              id: ci_build_id
+              run: echo "::set-output name=value::$GITHUB_SHA-$(date +"%s")"
+
+    e2e:
+        runs-on: ubuntu-latest
+        needs: [install, cypress_id]
+
+        strategy:
+            matrix:
+                containers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 12.x
+
+            - uses: actions/cache@v2
+              id: yarn-cache
+              with:
+                  path: '**/node_modules'
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+
+            - name: Install Cypress binary
+              run: yarn cypress install
+
+            - name: End-to-End tests
+              uses: cypress-io/github-action@v2
+              with:
+                  ci-build-id: '${{ needs.cypress_id.outputs.ci_build_id }}'
+                  install: false
+                  record: true
+                  parallel: true
+                  start: ${{ env.SERVER_START_CMD }}
+                  wait-on: ${{ env.SERVER_URL }}
+                  wait-on-timeout: 300
+                  cache-key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  group: 'e2e'
+                  tag: ${{ github.event_name }}
+              env:
+                  CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+                  COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
+                  STORYBOOK_TESTING: true
+                  SERVER_START_CMD: 'yarn cy:server'
+                  SERVER_URL: 'http://localhost:5001'
 
     publish:
         runs-on: ubuntu-latest


### PR DESCRIPTION
https://jira.dhis2.org/browse/CLI-36

Since I was already working on the workflows, I thought I'd tackle this one while I'm at it. Cypress CI runs can't be restarted with our current config (see https://jira.dhis2.org/browse/CLI-36). This fixes that by passing a unique id for each workflow run.

FYI, for this repo e2e hasn't been enabled yet, so currently the task will fail because of that.