### PR TITLE
fix(job-type-field): filter non-implemented jobTypes

### DIFF
--- a/src/components/FormFields/JobTypeField.js
+++ b/src/components/FormFields/JobTypeField.js
@@ -18,10 +18,13 @@ const VALIDATOR = composeValidators(string, hasValue)
 
 const JobTypeField = () => {
     const jobTypes = hooks.useAllJobTypes()
-    const options = jobTypes.map(({ jobType }) => ({
-        value: jobType,
-        label: jobTypesMap[jobType],
-    }))
+    const options = jobTypes
+        .map(({ jobType }) => ({
+            value: jobType,
+            label: jobTypesMap[jobType],
+        }))
+        .filter(job => !!job.label)
+        .sort((job1, job2) => job1.label.localeCompare(job2.label))
 
     return (
         <Field


### PR DESCRIPTION

The JobType `TRACKER_SEARCH_OPTIMIZATION` is not implemented yet, and thus shows as a blank field in the input selection. The API for implementing this jobType does not seem complete: https://jira.dhis2.org/browse/DHIS2-12048 . This prevents future new non-implemented jobTypes from showing as blank fields in the selector. 

Also added sorting of the Job-types. A bit debatable if this should be added here, but I think it's a good quality of life improvement.