### PR TITLE
fix(system-jobs): always allow running jobs manually

### DIFF
--- a/src/components/JobTable/Actions.js
+++ b/src/components/JobTable/Actions.js
@@ -17,13 +17,7 @@ const Actions = ({ id, configurable, enabled, refetch }) => (
                 ) : (
                     <ViewJobAction id={id} />
                 )}
-                {configurable && (
-                    <RunJobAction
-                        enabled={enabled}
-                        id={id}
-                        onComplete={refetch}
-                    />
-                )}
+                <RunJobAction enabled={enabled} id={id} onComplete={refetch} />
                 {configurable && (
                     <DeleteJobAction id={id} onSuccess={refetch} />
                 )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5241,7 +5241,12 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001166, caniuse-lite@^1.0.30001179, caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001489:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001166, caniuse-lite@^1.0.30001179:
+  version "1.0.30001415"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001415.tgz"
+  integrity sha512-ER+PfgCJUe8BqunLGWd/1EY4g8AzQcsDAVzdtMGKVtQEmKAwaFfU6vb7EAVIqTMYsqxBorYZi2+22Iouj/y7GQ==
+
+caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001489:
   version "1.0.30001494"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001494.tgz#3e56e04a48da7a79eae994559eb1ec02aaac862f"
   integrity sha512-sY2B5Qyl46ZzfYDegrl8GBCzdawSLT4ThM9b9F+aDYUrAG2zCOyMbd2Tq34mS1g4ZKBfjRlzOohQMxx28x6wJg==


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/TECH-1300

Before this fix we used to check whether a job was configurable and show a manual run option only if it was. Currently we don't want to block manual runs for system jobs anymore, so I've removed the condition. Manual run will be available for all types of jobs.

The dialog for system jobs before this fix:

![image](https://user-images.githubusercontent.com/7355199/193770117-25ff7efe-e83e-44ff-87fe-b3a528ba0638.png)

And after this fix:

![image](https://user-images.githubusercontent.com/7355199/193769945-036193b5-8236-4c39-a108-6fda1e3a5ee8.png)

Triggering a manual run of a system job will send this kind of POST:

![image](https://user-images.githubusercontent.com/7355199/193769670-1da81fee-2b9d-4b0c-b523-1f1b08d5cddc.png)
