### PR TITLE
fix(node): update node 12 to node 16

### DIFF
--- a/.github/workflows/dhis2-netlify-deploy-pr.yml
+++ b/.github/workflows/dhis2-netlify-deploy-pr.yml
@@ -24,7 +24,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
-                  node-version: 12.x
+                  node-version: 16.x
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile

--- a/.github/workflows/dhis2-netlify-deploy-pr.yml
+++ b/.github/workflows/dhis2-netlify-deploy-pr.yml
@@ -22,9 +22,9 @@ jobs:
         if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 16.x
+                  node-version: 16
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile

--- a/.github/workflows/dhis2-netlify-deploy-production.yml
+++ b/.github/workflows/dhis2-netlify-deploy-production.yml
@@ -23,9 +23,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 16.x
+                  node-version: 16
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -27,9 +27,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 16.x
+                  node-version: 16
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
@@ -49,9 +49,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 16.x
+                  node-version: 16
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
@@ -68,9 +68,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 16.x
+                  node-version: 16
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
@@ -96,9 +96,9 @@ jobs:
     #        - name: Checkout
     #          uses: actions/checkout@v2
     #
-    #        - uses: actions/setup-node@v1
+    #        - uses: actions/setup-node@v3
     #          with:
-    #              node-version: 16.x
+    #              node-version: 16
     #
     #        - name: End-to-End tests
     #          uses: cypress-io/github-action@v2
@@ -126,9 +126,9 @@ jobs:
               with:
                   token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
 
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 16.x
+                  node-version: 16
 
             - uses: actions/download-artifact@v2
               with:

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -29,7 +29,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
-                  node-version: 12.x
+                  node-version: 16.x
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
@@ -51,7 +51,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
-                  node-version: 12.x
+                  node-version: 16.x
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
@@ -70,7 +70,7 @@ jobs:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
-                  node-version: 12.x
+                  node-version: 16.x
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
@@ -98,7 +98,7 @@ jobs:
     #
     #        - uses: actions/setup-node@v1
     #          with:
-    #              node-version: 12.x
+    #              node-version: 16.x
     #
     #        - name: End-to-End tests
     #          uses: cypress-io/github-action@v2
@@ -128,7 +128,7 @@ jobs:
 
             - uses: actions/setup-node@v1
               with:
-                  node-version: 12.x
+                  node-version: 16.x
 
             - uses: actions/download-artifact@v2
               with:


### PR DESCRIPTION
As discussed, node 12 is EOL. There are some deprecations in node 18 that we need to address, so node 16 is the most modern version we can update to at the moment.