### PR TITLE
ci(e2e): reenable e2e tests

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -83,43 +83,35 @@ jobs:
             - name: Test
               run: yarn d2-app-scripts test
 
-    #e2e:
-    #    runs-on: ubuntu-latest
-    #    if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
-    #
-    #    strategy:
-    #        fail-fast: false
-    #        matrix:
-    #            containers: [1, 2, 3, 4]
-    #
-    #    steps:
-    #        - name: Checkout
-    #          uses: actions/checkout@v2
-    #
-    #        - uses: actions/setup-node@v3
-    #          with:
-    #              node-version: 16
-    #
-    #        - name: End-to-End tests
-    #          uses: cypress-io/github-action@v2
-    #          with:
-    #              # This should be a command that serves the app.
-    #              start: yarn d2-app-scripts start
-    #              wait-on: 'http://localhost:3000'
-    #              wait-on-timeout: 300
-    #              record: true
-    #              parallel: true
-    #          env:
-    #              BROWSER: none
-    #              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #              CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-    #              CYPRESS_dhis2BaseUrl: https://debug.dhis2.org/dev
-    #              CYPRESS_dhis2ApiVersion: 37
-    #              CYPRESS_networkMode: stub
+    e2e:
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                containers: [1, 2, 3, 4]
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: 16
+            - name: End-to-End tests
+              uses: cypress-io/github-action@v2
+              with:
+                  start: yarn start:nobrowser
+                  wait-on: 'http://localhost:3000'
+                  wait-on-timeout: 300
+                  record: true
+                  parallel: true
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+                  CYPRESS_dhis2BaseUrl: http://localhost:8080
+                  CYPRESS_dhis2ApiVersion: 38
+                  CYPRESS_networkMode: stub
 
     release:
         runs-on: ubuntu-latest
-        needs: [build, lint, test] # add e2e if you use it
+        needs: [build, lint, test, e2e]
         if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
E2e tests were accidentally disabled here it seems: https://github.com/dhis2/scheduler-app/commit/934d73502fe9707fb12e31990ec548482d74fd29#diff-1d835fdd19fc1d6a0129eb898bf4593f444624610ad0ee1311c1a7ae906f70b7R86. This could go unnoticed because these checks aren't required.

This reenables the e2e tests. We should also make them required in the repo settings.