### PR TITLE
chore(cypress): set capture to update against debug/dev

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -6,7 +6,7 @@
     "video": false,
     "env": {
         "dhis2DataTestPrefix": "dhis2-scheduler",
-        "networkMode": "live",
-        "dhis2ApiVersion": "38"
+        "dhis2BaseUrl": "https://debug.dhis2.org/dev",
+        "dhis2ApiVersion": "40"
     }
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
         "lint:css": "stylelint './src/**/*.css' && prettier './src/**/*.css' --check",
         "format": "d2-style apply && yarn format:css",
         "format:css": "prettier './src/**/*.css' --write",
-        "cypress:capture": "start-server-and-test 'yarn start:nobrowser' http://localhost:3000 'yarn cypress run --env dhis2ApiVersion=38,networkMode=capture'",
-        "cypress:stub": "start-server-and-test 'yarn start:nobrowser' http://localhost:3000 'yarn cypress run --env dhis2ApiVersion=38,networkMode=stub'",
+        "cypress:capture": "start-server-and-test 'yarn start:nobrowser' http://localhost:3000 'yarn cypress run --env networkMode=capture'",
+        "cypress:stub": "start-server-and-test 'yarn start:nobrowser' http://localhost:3000 'yarn cypress run --env networkMode=stub'",
         "cypress:live": "start-server-and-test 'yarn start:nobrowser' http://localhost:3000 'yarn cypress open --env networkMode=live'"
     },
     "dependencies": {


### PR DESCRIPTION
This branch reproduces an error that occurs when you try to update the cypress fixtures. Running `cypress:capture` will fail with the following error:

![image](https://user-images.githubusercontent.com/7355199/220610812-6446ed88-12d3-4200-af12-dd32e6b0f945.png)

For #461 I'm updating the fixtures to the latest API version, but this is blocking that update.