### PR TITLE
fix(parameter-options): return empty array if parameter options do not exist

### DIFF
--- a/src/components/Store/hooks.js
+++ b/src/components/Store/hooks.js
@@ -86,5 +86,6 @@ export const useJobTypeParameters = (jobType) => {
 // Returns the parameter options for a given parameter
 export const useParameterOptions = (parameter) => {
     const parameterOptions = useAllParameterOptions()
-    return parameterOptions[parameter]
+
+    return parameterOptions[parameter] || []
 }


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/DHIS2-15095. Note that this just fixes the crash. Parameters of the `java.util.List` type usually need to fetch their options. We need a `relativeApiEndpoint` for this parameter type if that's the case, and add the query manually as it needs to be static.