### PR TITLE
chore: specify 2.40 as minimum version

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -12,7 +12,7 @@ const config = {
     description,
     type: 'app',
     id: '2eacfda3-e887-4121-80bc-63ee82fba5e9',
-    minDHIS2Version: '2.36',
+    minDHIS2Version: '2.40',
     coreApp: true,
     entryPoints: {
         app: './src/components/App/index.js',

--- a/package.json
+++ b/package.json
@@ -70,5 +70,5 @@
             "\\.css$": "identity-obj-proxy"
         }
     },
-    "version": "100.2.12"
+    "version": "101.0.00"
 }


### PR DESCRIPTION
This sets the min version for the changes in the PR. 2.40 is the first version that includes the endpoints used in the PR.