### PR TITLE
chore: specify 2.39 as maximum version

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -13,6 +13,7 @@ const config = {
     type: 'app',
     id: '2eacfda3-e887-4121-80bc-63ee82fba5e9',
     minDHIS2Version: '2.36',
+    maxDHIS2Version: '2.39',
     coreApp: true,
     entryPoints: {
         app: './src/components/App/index.js',


### PR DESCRIPTION
Upcoming changes require 2.40 as the minimum version. Current app will be kept around for versions below 2.40.