### PR TITLE
ci(cache): update workflows to recommended caching approach

### DIFF
--- a/.github/workflows/dhis2-netlify-deploy-pr.yml
+++ b/.github/workflows/dhis2-netlify-deploy-pr.yml
@@ -25,8 +25,8 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - name: Build

--- a/.github/workflows/dhis2-netlify-deploy-production.yml
+++ b/.github/workflows/dhis2-netlify-deploy-production.yml
@@ -26,8 +26,8 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - name: Build

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -30,8 +30,8 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - name: Build
@@ -52,8 +52,8 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             # Can be removed if translations aren't required for tests,
@@ -71,8 +71,8 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             # Can be removed if translations aren't required for tests,
@@ -121,13 +121,13 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
             - uses: actions/download-artifact@v2
               with:
                   name: app-build
 
             # ensure that d2-app-scripts is available
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - uses: dhis2/action-semantic-release@master

--- a/.github/workflows/dhis2-verify-commits.yml
+++ b/.github/workflows/dhis2-verify-commits.yml
@@ -9,7 +9,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: c-hive/gha-yarn-cache@v1
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: 16
+                  cache: 'yarn'
             - run: yarn install --frozen-lockfile
             - id: commitlint
               run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")
@@ -23,7 +26,10 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   fetch-depth: 0
-            - uses: c-hive/gha-yarn-cache@v1
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: 16
+                  cache: 'yarn'
             - run: yarn install --frozen-lockfile
             - id: commitlint
               run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")


### PR DESCRIPTION
https://github.com/c-hive/gha-yarn-cache is deprecated. It has been integrated in https://github.com/actions/setup-node, see: https://github.com/actions/setup-node#caching-global-packages-data. This applies the recommended migration.