### PR TITLE
refactor(submit-hooks): accept onSuccess callback for submission hooks

### DIFF
--- a/src/components/Forms/JobAddFormContainer.js
+++ b/src/components/Forms/JobAddFormContainer.js
@@ -1,13 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { ReactFinalForm } from '@dhis2/ui'
+import history from '../../services/history'
 import { useSubmitJob } from '../../hooks/jobs'
 import JobAddForm from './JobAddForm'
 
 const { Form } = ReactFinalForm
 
 const JobAddFormContainer = ({ setIsPristine }) => {
-    const [submitJob] = useSubmitJob()
+    const redirect = () => {
+        history.push('/')
+    }
+    const [submitJob] = useSubmitJob({ onSuccess: redirect })
 
     /**
      * destroyOnUnregister is enabled so that dynamic fields will be unregistered

--- a/src/components/Forms/JobEditFormContainer.js
+++ b/src/components/Forms/JobEditFormContainer.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { ReactFinalForm } from '@dhis2/ui'
 import { useParams } from 'react-router-dom'
+import history from '../../services/history'
 import { useUpdateJob } from '../../hooks/jobs'
 import JobEditForm from './JobEditForm'
 
@@ -23,7 +24,10 @@ const initialFields = [
 
 const JobEditFormContainer = ({ job, setIsPristine }) => {
     const { id } = useParams()
-    const [updateJob] = useUpdateJob({ id })
+    const redirect = () => {
+        history.push('/')
+    }
+    const [updateJob] = useUpdateJob({ id, onSuccess: redirect })
 
     // Creating an object with just the values we want to use as initial values
     const initialValues = initialFields.reduce((filtered, key) => {

--- a/src/components/Forms/SequenceAddFormContainer.js
+++ b/src/components/Forms/SequenceAddFormContainer.js
@@ -1,13 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { ReactFinalForm } from '@dhis2/ui'
+import history from '../../services/history'
 import { useSubmitJobQueue } from '../../hooks/job-queues'
 import SequenceAddForm from './SequenceAddForm'
 
 const { Form } = ReactFinalForm
 
 const SequenceAddFormContainer = ({ setIsPristine }) => {
-    const [submitJobQueue] = useSubmitJobQueue()
+    const redirect = () => {
+        history.push('/')
+    }
+    const [submitJobQueue] = useSubmitJobQueue({ onSuccess: redirect })
 
     /**
      * destroyOnUnregister is enabled so that dynamic fields will be unregistered

--- a/src/hooks/job-queues/use-submit-job-queue.js
+++ b/src/hooks/job-queues/use-submit-job-queue.js
@@ -1,5 +1,4 @@
 import { useDataEngine } from '@dhis2/app-runtime'
-import history from '../../services/history'
 import formatError from '../../services/format-error'
 
 const createMutation = (name) => ({
@@ -8,14 +7,16 @@ const createMutation = (name) => ({
     data: ({ queue }) => queue,
 })
 
-const useSubmitJobQueue = () => {
+const useSubmitJobQueue = ({ onSuccess } = {}) => {
     const engine = useDataEngine()
     const submitJobQueue = (queue) => {
         const mutation = createMutation(queue.name)
         return engine
             .mutate(mutation, { variables: { queue } })
             .then(() => {
-                history.push('/')
+                if (onSuccess) {
+                    onSuccess()
+                }
             })
             .catch((error) => {
                 const isValidationError = error.type === 'access'

--- a/src/hooks/job-queues/use-submit-job-queue.test.js
+++ b/src/hooks/job-queues/use-submit-job-queue.test.js
@@ -1,5 +1,4 @@
 import { useDataEngine } from '@dhis2/app-runtime'
-import history from '../../services/history'
 import formatError from '../../services/format-error'
 import useSubmitJobQueue from './use-submit-job-queue'
 
@@ -7,24 +6,21 @@ jest.mock('@dhis2/app-runtime', () => ({
     useDataEngine: jest.fn(),
 }))
 
-jest.mock('../../services/history', () => ({
-    push: jest.fn(),
-}))
-
 jest.mock('../../services/format-error', () => jest.fn())
 
 describe('useSubmitJobQueue', () => {
-    it('should redirect to root', () => {
+    it('should call onSuccess on success', () => {
+        const spy = jest.fn()
         const engine = {
             mutate: () => Promise.resolve(),
         }
         useDataEngine.mockImplementation(() => engine)
-        const [submitJobQueue] = useSubmitJobQueue()
+        const [submitJobQueue] = useSubmitJobQueue({ onSuccess: spy })
 
         expect.assertions(1)
 
         submitJobQueue({ name: 'name' }).then(() => {
-            expect(history.push).toHaveBeenCalledWith('/')
+            expect(spy).toHaveBeenCalled()
         })
     })
 

--- a/src/hooks/jobs/use-submit-job.js
+++ b/src/hooks/jobs/use-submit-job.js
@@ -1,5 +1,4 @@
 import { useDataEngine } from '@dhis2/app-runtime'
-import history from '../../services/history'
 import formatError from '../../services/format-error'
 
 const mutation = {
@@ -8,13 +7,15 @@ const mutation = {
     data: /* istanbul ignore next */ ({ job }) => job,
 }
 
-const useSubmitJob = () => {
+const useSubmitJob = ({ onSuccess } = {}) => {
     const engine = useDataEngine()
     const submitJob = (job) =>
         engine
             .mutate(mutation, { variables: { job } })
             .then(() => {
-                history.push('/')
+                if (onSuccess) {
+                    onSuccess()
+                }
             })
             .catch((error) => {
                 const isValidationError = error.type === 'access'

--- a/src/hooks/jobs/use-submit-job.test.js
+++ b/src/hooks/jobs/use-submit-job.test.js
@@ -1,5 +1,4 @@
 import { useDataEngine } from '@dhis2/app-runtime'
-import history from '../../services/history'
 import formatError from '../../services/format-error'
 import useSubmitJob from './use-submit-job'
 
@@ -7,24 +6,21 @@ jest.mock('@dhis2/app-runtime', () => ({
     useDataEngine: jest.fn(),
 }))
 
-jest.mock('../../services/history', () => ({
-    push: jest.fn(),
-}))
-
 jest.mock('../../services/format-error', () => jest.fn())
 
 describe('useSubmitJob', () => {
-    it('should redirect to root', () => {
+    it('should call onSuccess on success', () => {
+        const spy = jest.fn()
         const engine = {
             mutate: () => Promise.resolve(),
         }
         useDataEngine.mockImplementation(() => engine)
-        const [submitJob] = useSubmitJob()
+        const [submitJob] = useSubmitJob({ onSuccess: spy })
 
         expect.assertions(1)
 
         submitJob().then(() => {
-            expect(history.push).toHaveBeenCalledWith('/')
+            expect(spy).toHaveBeenCalled()
         })
     })
 

--- a/src/hooks/jobs/use-update-job.js
+++ b/src/hooks/jobs/use-update-job.js
@@ -1,5 +1,4 @@
 import { useDataEngine } from '@dhis2/app-runtime'
-import history from '../../services/history'
 import formatError from '../../services/format-error'
 
 const mutation = {
@@ -9,13 +8,15 @@ const mutation = {
     data: /* istanbul ignore next */ ({ job }) => job,
 }
 
-const useUpdateJob = ({ id }) => {
+const useUpdateJob = ({ onSuccess, id } = {}) => {
     const engine = useDataEngine()
     const updateJob = (job) =>
         engine
             .mutate(mutation, { variables: { job, id } })
             .then(() => {
-                history.push('/')
+                if (onSuccess) {
+                    onSuccess()
+                }
             })
             .catch((error) => {
                 const isValidationError = error.type === 'access'

--- a/src/hooks/jobs/use-update-job.test.js
+++ b/src/hooks/jobs/use-update-job.test.js
@@ -1,5 +1,4 @@
 import { useDataEngine } from '@dhis2/app-runtime'
-import history from '../../services/history'
 import formatError from '../../services/format-error'
 import useUpdateJob from './use-update-job'
 
@@ -7,24 +6,21 @@ jest.mock('@dhis2/app-runtime', () => ({
     useDataEngine: jest.fn(),
 }))
 
-jest.mock('../../services/history', () => ({
-    push: jest.fn(),
-}))
-
 jest.mock('../../services/format-error', () => jest.fn())
 
 describe('useUpdateJob', () => {
-    it('should redirect to root', () => {
+    it('should call onSuccess on success', () => {
+        const spy = jest.fn()
         const engine = {
             mutate: () => Promise.resolve(),
         }
         useDataEngine.mockImplementation(() => engine)
-        const [updateJob] = useUpdateJob({ id: 'id' })
+        const [updateJob] = useUpdateJob({ id: 'id', onSuccess: spy })
 
         expect.assertions(1)
 
         return updateJob().then(() => {
-            expect(history.push).toHaveBeenCalledWith('/')
+            expect(spy).toHaveBeenCalled()
         })
     })
 


### PR DESCRIPTION
Removes the hardcoded redirect on success and allows us to get rid of some of the mocking.

https://dhis2.atlassian.net/browse/LIBS-515