### PR TITLE
ci(cypress): stop using cypress dashboard

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -85,10 +85,6 @@ jobs:
 
     e2e:
         runs-on: ubuntu-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                containers: [1, 2, 3, 4]
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v3
@@ -100,11 +96,8 @@ jobs:
                   start: yarn start:nobrowser
                   wait-on: 'http://localhost:3000'
                   wait-on-timeout: 300
-                  record: true
-                  parallel: true
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
                   CYPRESS_dhis2BaseUrl: https://debug.dhis2.org/dev
                   CYPRESS_dhis2ApiVersion: 41
                   CYPRESS_networkMode: stub


### PR DESCRIPTION
Since we're running out of credits often for cypress I've disabled recording and parallelization. Not as fast, but it won't cost us any cypress credits and it'll at least run again.