### PR TITLE
fix: update label to indicate job is attempting to run now

### DIFF
--- a/src/components/JobTable/NextRun.js
+++ b/src/components/JobTable/NextRun.js
@@ -28,12 +28,17 @@ const NextRun = ({ nextExecutionTime, enabled }) => {
     const nextRunIsInPast = nextRun.getTime() <= now
 
     /**
-     * If the time is in the past, that could mean that the task is running,
-     * and the nextExecutionTime hasn't been updated yet.
+     * If the nextExecutionTime is in the past that means that
+     * the scheduled execution time has passed, but the allowed
+     * startup delay hasn't expired yet. Effectively this means
+     * that the backend will start the job as soon as possible.
+     *
+     * If the window expires before the job can execute the
+     * nextExecutionTime will be updated to a time in the future.
      */
 
     if (nextRunIsInPast) {
-        return i18n.t('Not scheduled')
+        return i18n.t('Now')
     }
 
     return (

--- a/src/components/JobTable/NextRun.test.js
+++ b/src/components/JobTable/NextRun.test.js
@@ -47,8 +47,8 @@ describe('<NextRun>', () => {
         expect(wrapper.find(Tooltip).prop('content')).toEqual(expected)
     })
 
-    it('returns fallback message for an enabled job and a past execution time', () => {
-        const expected = 'Not scheduled'
+    it('returns message for an enabled job and a past execution time', () => {
+        const expected = 'Now'
         jest.spyOn(global.Date, 'now').mockImplementation(() => now)
 
         const wrapper = shallow(


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-14787
https://dhis2.atlassian.net/browse/DHIS2-15764 (partially)

We used to show `Not scheduled` under the `Next run` column for jobs that had their `nextExecutionTime` in the past, like so:

<img width="1150" alt="Screenshot 2024-02-01 at 16 24 54" src="https://github.com/dhis2/scheduler-app/assets/7355199/e09fa128-bdc7-4599-84ea-3a0d6ead09c4">

The intention was to indicate to users that the next run hadn't been planned yet, because the backend was working on executing it at that point, and would only schedule a new job after. That was confusing users a little, because we still showed `scheduled` as the job status.

So to indicate that the backend is currently working on trying to execute the job, this changes that to show `Now` instead:

<img width="1151" alt="Screenshot 2024-02-01 at 16 26 21" src="https://github.com/dhis2/scheduler-app/assets/7355199/71e81223-a1a6-4188-8af8-7fc926595297">

Since we don't have a lot of space to tell the user the whole story, "Now" seems the most correct and easy to understand.