### PR TITLE
fix: align cron expressions with labels

### DIFF
--- a/src/components/Modal/CronPresetModal.js
+++ b/src/components/Modal/CronPresetModal.js
@@ -18,7 +18,7 @@ const cronPresets = [
     },
     {
         label: i18n.t('Every day at midnight'),
-        value: '0 0 1 ? * *',
+        value: '0 0 0 ? * *',
     },
     {
         label: i18n.t('Every day at 3 am'),
@@ -26,7 +26,7 @@ const cronPresets = [
     },
     {
         label: i18n.t('Every day at noon'),
-        value: '0 0 12 ? * MON-FRI',
+        value: '0 0 12 ? * *',
     },
     {
         label: i18n.t('Every week'),


### PR DESCRIPTION
Some of our cron labels were incorrect: https://dhis2.atlassian.net/browse/DHIS2-12570. I've fixed the cron expressions to actually be the schedules that the labels are describing.

As a follow up issue we could look into creating a better selection of presets. I'll create a Jira issue for that.