### PR TITLE
fix(data-integrity): change default report type to summary

### DIFF
--- a/cypress/integration/add-job/create-parameterless-jobs/index.js
+++ b/cypress/integration/add-job/create-parameterless-jobs/index.js
@@ -57,7 +57,7 @@ Then(
         saveAndExpect({
             cronExpression: '0 0 * ? * *',
             jobParameters: {
-                type: 'REPORT',
+                type: 'SUMMARY',
             },
             jobType: 'DATA_INTEGRITY',
             name: 'Name',

--- a/cypress/integration/edit-job/edit-parameterless-jobs/index.js
+++ b/cypress/integration/edit-job/edit-parameterless-jobs/index.js
@@ -73,7 +73,7 @@ Then('the job is updated when the user saves the data integrity job', () =>
     saveAndExpect({
         jobType: 'DATA_INTEGRITY',
         jobParameters: {
-            type: 'REPORT',
+            type: 'SUMMARY',
         },
         name: 'Name',
         cronExpression: '0 0 * ? * *',

--- a/src/components/FormFields/Custom/DataIntegrityReportTypeField.js
+++ b/src/components/FormFields/Custom/DataIntegrityReportTypeField.js
@@ -6,7 +6,7 @@ import { getReportTypeLabel } from '../../../services/server-translations/dataIn
 
 const { Field } = ReactFinalForm
 
-const DEFAULT_VALUE = 'REPORT'
+const DEFAULT_VALUE = 'SUMMARY'
 
 const DataIntegrityReportTypeField = ({ name, constants }) => {
     if (!constants) {
@@ -23,7 +23,7 @@ const DataIntegrityReportTypeField = ({ name, constants }) => {
         <Field
             name={name}
             component={SingleSelectFieldFF}
-            initialValue={DEFAULT_VALUE}
+            defaultValue={DEFAULT_VALUE}
             options={labeledOptions}
             label={i18n.t('Report type')}
         />


### PR DESCRIPTION
Changes the defaultValue of `Report` type for `Data integrity` job to be `summary` instead of `report`.
Report is a legacy type, and isn't really useful at all when scheduling. So we may remove this completely.

Also fixes a bug where I'd used `initialValue` for the field instead of `defaultValue`. This is the wrong prop to use it in this case. Because `initialValue` would override the `initialValues` on the form, and meant this field would always be set to `report` when you edited a job. Which is actually a quite bad bug.
I just discovered this bug when trying to schedule summary jobs in conjunction with the new Data Integrity UI in `Data Administration` app.
However, this bug does not seem to happen in 2.39 and 2.38. I am not sure what introduced it, but it seems like it's currectly in 2.40 and master/dev.


Also updated `Run all available checks`-label to `Run all standard checks`. Because `slow: true`-checks will not be run this is selected, so right now it's quite misleading. `Standard` is the term used in `Data Administration` UI for checks that are not slow.
