### PR TITLE
fix(data-integrity): add indicator for slow checks

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-03-05T14:54:55.437Z\n"
-"PO-Revision-Date: 2024-03-05T14:54:55.437Z\n"
+"POT-Creation-Date: 2024-03-13T13:19:06.504Z\n"
+"PO-Revision-Date: 2024-03-13T13:19:06.504Z\n"
 
 msgid "Something went wrong"
 msgstr "Something went wrong"
@@ -57,14 +57,20 @@ msgstr "Something went wrong whilst fetching options"
 msgid "Checks to run"
 msgstr "Checks to run"
 
-msgid "Run all available checks"
-msgstr "Run all available checks"
+msgid "Run all standard checks"
+msgstr "Run all standard checks"
 
 msgid "Only run selected checks"
 msgstr "Only run selected checks"
 
 msgid "Severity"
 msgstr "Severity"
+
+msgid "Slow checks are resource intensive and should be run with caution"
+msgstr "Slow checks are resource intensive and should be run with caution"
+
+msgid "Slow"
+msgstr "Slow"
 
 msgid "Select checks to run."
 msgstr "Select checks to run."

--- a/src/components/FormFields/Custom/DataIntegrityChecksField.js
+++ b/src/components/FormFields/Custom/DataIntegrityChecksField.js
@@ -125,7 +125,11 @@ const LabelComponent = ({ label, severity, highlighted, disabled, isSlow }) => (
                 })}
             >{`${i18n.t('Severity')}: ${severity}`}</span>
             {isSlow && (
-                <Tooltip content={i18n.t('Slow checks are resource intensive and should be run with caution')}>
+                <Tooltip
+                    content={i18n.t(
+                        'Slow checks are resource intensive and should be run with caution'
+                    )}
+                >
                     <Chip dense>{i18n.t('Slow')}</Chip>
                 </Tooltip>
             )}

--- a/src/components/FormFields/Custom/DataIntegrityChecksField.js
+++ b/src/components/FormFields/Custom/DataIntegrityChecksField.js
@@ -83,7 +83,7 @@ const DataIntegrityChecksField = ({ label, name }) => {
             <Radio
                 name={'checksToRun'}
                 value={'false'}
-                label={i18n.t('Run all available checks')}
+                label={i18n.t('Run all standard checks')}
                 checked={!runSelected}
                 onChange={toggle}
             />

--- a/src/components/FormFields/Custom/DataIntegrityChecksField.js
+++ b/src/components/FormFields/Custom/DataIntegrityChecksField.js
@@ -8,9 +8,11 @@ import {
     Radio,
     Transfer,
     TransferOption,
+    Tooltip,
     ReactFinalForm,
     InputFieldFF,
     Help,
+    Chip,
 } from '@dhis2/ui'
 import cx from 'classnames'
 import { useParameterOption } from '../../../hooks/parameter-options'
@@ -123,9 +125,9 @@ const LabelComponent = ({ label, severity, highlighted, disabled, isSlow }) => (
                 })}
             >{`${i18n.t('Severity')}: ${severity}`}</span>
             {isSlow && (
-                <span className={styles.optionSlowIndicator}>
-                    {i18n.t('Resource intensive')}
-                </span>
+                <Tooltip content={i18n.t('Slow checks are resource intensive and should be run with caution')}>
+                    <Chip dense>{i18n.t('Slow')}</Chip>
+                </Tooltip>
             )}
         </div>
     </div>

--- a/src/components/FormFields/Custom/DataIntegrityChecksField.js
+++ b/src/components/FormFields/Custom/DataIntegrityChecksField.js
@@ -108,7 +108,7 @@ const DataIntegrityChecksField = ({ label, name }) => {
     )
 }
 
-const LabelComponent = ({ label, severity, highlighted, disabled }) => (
+const LabelComponent = ({ label, severity, highlighted, disabled, isSlow }) => (
     <div
         className={cx(styles.transferOption, {
             [styles.highlighted]: highlighted,
@@ -116,11 +116,18 @@ const LabelComponent = ({ label, severity, highlighted, disabled }) => (
         })}
     >
         <div className={styles.optionName}>{label}</div>
-        <div
-            className={cx(styles.optionSeverity, {
-                [styles.highlighted]: highlighted,
-            })}
-        >{`${i18n.t('Severity')}: ${severity}`}</div>
+        <div className={styles.optionSubtitle}>
+            <span
+                className={cx(styles.optionSeverity, {
+                    [styles.highlighted]: highlighted,
+                })}
+            >{`${i18n.t('Severity')}: ${severity}`}</span>
+            {isSlow && (
+                <span className={styles.optionSlowIndicator}>
+                    {i18n.t('Resource intensive')}
+                </span>
+            )}
+        </div>
     </div>
 )
 

--- a/src/components/FormFields/Custom/DataIntegrityChecksField.js
+++ b/src/components/FormFields/Custom/DataIntegrityChecksField.js
@@ -12,7 +12,7 @@ import {
     ReactFinalForm,
     InputFieldFF,
     Help,
-    Chip,
+    Tag,
 } from '@dhis2/ui'
 import cx from 'classnames'
 import { useParameterOption } from '../../../hooks/parameter-options'
@@ -130,7 +130,7 @@ const LabelComponent = ({ label, severity, highlighted, disabled, isSlow }) => (
                         'Slow checks are resource intensive and should be run with caution'
                     )}
                 >
-                    <Chip dense>{i18n.t('Slow')}</Chip>
+                    <Tag>{i18n.t('Slow')}</Tag>
                 </Tooltip>
             )}
         </div>

--- a/src/components/FormFields/Custom/DataIntegrityChecksField.module.css
+++ b/src/components/FormFields/Custom/DataIntegrityChecksField.module.css
@@ -1,21 +1,36 @@
 .transfer {
-    margin-top: 8px;
+    margin-block-start: var(--spacers-dp8);
 }
 
 .transferOption {
+    display: flex;
+    flex-direction: column;
     font-size: 14px;
     padding: 4px 0;
+    gap: 6px;
 }
 
 .optionName {
     font-weight: 500;
-    margin-bottom: 4px;
+}
+
+.optionSubtitle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-weight: 400;
+    font-size: 13px;
 }
 
 .optionSeverity {
-    font-weight: 400;
-    font-size: 13px;
     color: var(--colors-grey600);
+}
+
+.optionSlowIndicator {
+    background-color: var(--colors-yellow100);
+    color: var(--colors-grey800);
+    padding: 4px 6px;
+    border-radius: 2px;
 }
 
 .transferOption.highlighted .optionSeverity {

--- a/src/components/FormFields/Custom/DataIntegrityChecksField.module.css
+++ b/src/components/FormFields/Custom/DataIntegrityChecksField.module.css
@@ -26,13 +26,6 @@
     color: var(--colors-grey600);
 }
 
-.optionSlowIndicator {
-    background-color: var(--colors-yellow100);
-    color: var(--colors-grey800);
-    padding: 4px 6px;
-    border-radius: 2px;
-}
-
 .transferOption.highlighted .optionSeverity {
     color: var(--colors-grey300);
 }


### PR DESCRIPTION
Adds an indicator to checks that have `isSlow: true`. The new UI in `Data Administration` separates these checks completely, because the user should be cautious when running these checks. So I think it's quite important to distinguish those here as well. 