### PR TITLE
fix: proptype errors

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-03-18T11:31:16.927Z\n"
-"PO-Revision-Date: 2024-03-18T11:31:16.927Z\n"
+"POT-Creation-Date: 2024-03-19T15:29:37.698Z\n"
+"PO-Revision-Date: 2024-03-19T15:29:37.698Z\n"
 
 msgid "Something went wrong"
 msgstr "Something went wrong"
@@ -563,6 +563,21 @@ msgstr "Executor"
 
 msgid "Receiver"
 msgstr "Receiver"
+
+msgid "Parent"
+msgstr "Parent"
+
+msgid "Fail"
+msgstr "Fail"
+
+msgid "Skip stage"
+msgstr "Skip stage"
+
+msgid "Skip item"
+msgstr "Skip item"
+
+msgid "Skip item outlier"
+msgstr "Skip item outlier"
 
 msgid "A CRON expression is required"
 msgstr "A CRON expression is required"

--- a/src/components/FormFields/QueueTransfer.js
+++ b/src/components/FormFields/QueueTransfer.js
@@ -5,7 +5,7 @@ import { Field, Transfer } from '@dhis2/ui'
 import QueueTransferTitle from './QueueTransferTitle'
 import QueueOption from './QueueOption'
 
-const { bool, arrayOf, shape, func, array, string } = PropTypes
+const { bool, arrayOf, shape, func, array, string, oneOfType } = PropTypes
 
 const QueueTransfer = ({ options, input, meta }) => {
     const { onChange, value } = input
@@ -21,7 +21,7 @@ const QueueTransfer = ({ options, input, meta }) => {
         >
             <Transfer
                 options={options}
-                selected={value}
+                selected={[...value]}
                 renderOption={QueueOption}
                 filterable
                 filterPlaceholder={i18n.t('Filter jobs')}
@@ -41,7 +41,7 @@ const QueueTransfer = ({ options, input, meta }) => {
 QueueTransfer.propTypes = {
     input: shape({
         onChange: func.isRequired,
-        value: array.isRequired,
+        value: oneOfType([string, array]).isRequired,
     }).isRequired,
     meta: shape({
         error: string,

--- a/src/components/JobDetails/JobDetails.js
+++ b/src/components/JobDetails/JobDetails.js
@@ -9,7 +9,9 @@ const JobDetails = ({ created, lastExecutedStatus, lastExecuted }) => {
     // Using Date.now allows for easier mocking
     const now = Date.now()
     const createdFromNow = moment(created).from(now)
-    const translatedStatus = jobStatusMap[lastExecutedStatus]
+    const translatedStatus = lastExecutedStatus
+        ? jobStatusMap[lastExecutedStatus]
+        : ''
     const lastRunFromNow = lastExecuted ? moment(lastExecuted).from(now) : ''
 
     return (
@@ -45,8 +47,8 @@ const { string } = PropTypes
 
 JobDetails.propTypes = {
     created: string.isRequired,
-    lastExecutedStatus: string.isRequired,
     lastExecuted: string,
+    lastExecutedStatus: string,
 }
 
 export default JobDetails

--- a/src/pages/JobEdit/JobEdit.js
+++ b/src/pages/JobEdit/JobEdit.js
@@ -46,8 +46,8 @@ JobEdit.propTypes = {
     job: shape({
         name: string.isRequired,
         created: string.isRequired,
-        lastExecutedStatus: string.isRequired,
-        lastExecuted: string.isRequired,
+        lastExecuted: string,
+        lastExecutedStatus: string,
     }).isRequired,
 }
 

--- a/src/pages/JobView/JobView.js
+++ b/src/pages/JobView/JobView.js
@@ -95,10 +95,10 @@ JobView.propTypes = {
     job: shape({
         name: string.isRequired,
         created: string.isRequired,
-        lastExecutedStatus: string.isRequired,
-        lastExecuted: string.isRequired,
         jobType: string.isRequired,
         cronExpression: string.isRequired,
+        lastExecuted: string,
+        lastExecutedStatus: string,
     }).isRequired,
 }
 


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-17022

See https://final-form.org/docs/react-final-form/api/Field for the fix I used in the last commit:

> Note: To use an array for the values (with another field type, like a tags-input component), you can do value={[...props.input.value]} to avoid "Invalid prop type of 'string' warning"

There are other ways to fix it, like defaultValues or initialValues. But initialValues on a field would override the ones we set on the form, which would prevent us seeding the form with data when editing a queue. And using a defaultValue would mean the form is dirty as soon as it's initialized, which is confusing for users. The fix suggested above is not ideal, but the least bad in my opinion.