### PR TITLE
fix: cron parsing number range [DHIS2-18859]

### DIFF
--- a/src/services/validators/validate-cron.js
+++ b/src/services/validators/validate-cron.js
@@ -28,7 +28,7 @@ const isValidNumberRange = (range, x, y) => {
     return (
         isValidNumber(boundaries[0], x, y) &&
         isValidNumber(boundaries[1], x, y) &&
-        boundaries[0] <= boundaries[1]
+        Number(boundaries[0]) <= Number(boundaries[1])
     )
 }
 

--- a/src/services/validators/validate-cron.test.js
+++ b/src/services/validators/validate-cron.test.js
@@ -36,6 +36,10 @@ describe('validateCron', () => {
         expect(validateCron('0 0 1-5 * * *')).toBe(true)
     })
 
+    it('should parse numbers properly in number ranges', () => {
+        expect(validateCron('0 0 4-23 * * *')).toBe(true)
+    })
+
     it('should allow ranges in fraction numerators', () => {
         expect(validateCron('0 0 10-22/2 ? * *')).toBe(true)
     })


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-18859

This fixes an issue where the parsing of cron expressions would compare two strings, e.g. `'4'`, and `'23'` and '4' < '23' evaluates to `false`.