### PR TITLE
fix: check if start of range is valid

### DIFF
--- a/src/services/validators/validate-cron.js
+++ b/src/services/validators/validate-cron.js
@@ -21,7 +21,7 @@ const isUndefined = (field) => field === '?'
 
 const isValidNumberRange = (range, x, y) => {
     const boundaries = range.split('-')
-    if (!boundaries || boundaries.length !== 2) {
+    if (!boundaries || boundaries.length !== 2 || boundaries[0].trim() === '') {
         return false
     }
 

--- a/src/services/validators/validate-cron.test.js
+++ b/src/services/validators/validate-cron.test.js
@@ -40,6 +40,18 @@ describe('validateCron', () => {
         expect(validateCron('0 0 4-23 * * *')).toBe(true)
     })
 
+    it('should reject number ranges that are missing a number at beginning', () => {
+        expect(validateCron('0 0 -23 * * *')).toBe(false)
+    })
+
+    it('should reject number ranges that are missing a number at beginning (with spaces)', () => {
+        expect(validateCron('0 0          -23 * * *')).toBe(false)
+    })
+
+    it('should reject number ranges that are missing a number at end', () => {
+        expect(validateCron('0 0 4- * * *')).toBe(false)
+    })
+
     it('should allow ranges in fraction numerators', () => {
         expect(validateCron('0 0 10-22/2 ? * *')).toBe(true)
     })


### PR DESCRIPTION
This PR fixes a bug that Lina noticed while testing https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-18859

The original ticket was to allow ranges like `4-23` whereas previously the validation check was making you enter `04-23`

When Lina was testing she was typing and had a point where she had something like `0 0 -23 * * *`. This was not rejected by our validator, which in turn led the app to crash because it is an invalid cron expression that was being passed to a cron expression interpreter (to output it in natural language).

Anyway, this bug is closely related to the ticket I was working on (it's another bug related to number ranges), so I think it makes sense to just put the fix on the original ticket.

I also considered adding a catch for the cron interpreter, but I think in general it might be better to crash the app with an invalid cron expression rather than to save it and have troubles with the job execution, so then I just left this alone.