### PR TITLE
fix: add new jobType name [DHIS2-12051]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-03-19T15:29:37.698Z\n"
-"PO-Revision-Date: 2024-03-19T15:29:37.698Z\n"
+"POT-Creation-Date: 2025-08-19T12:44:12.555Z\n"
+"PO-Revision-Date: 2025-08-19T12:44:12.556Z\n"
 
 msgid "Something went wrong"
 msgstr "Something went wrong"
@@ -554,6 +554,9 @@ msgstr "Tracker programs data sync"
 
 msgid "Tracker search optimization"
 msgstr "Tracker search optimization"
+
+msgid "Tracker trigram index maintenance"
+msgstr "Tracker trigram index maintenance"
 
 msgid "Validation results notification"
 msgstr "Validation results notification"

--- a/src/services/server-translations/jobTypesMap.js
+++ b/src/services/server-translations/jobTypesMap.js
@@ -52,7 +52,9 @@ const jobTypesMap = {
     TRACKER_IMPORT_RULE_ENGINE_JOB: i18n.t('Tracker import rule engine job'),
     TRACKER_PROGRAMS_DATA_SYNC: i18n.t('Tracker programs data sync'),
     TRACKER_SEARCH_OPTIMIZATION: i18n.t('Tracker search optimization'),
-    TRACKER_TRIGRAM_INDEX_MAINTENANCE: i18n.t('Tracker search optimization'),
+    TRACKER_TRIGRAM_INDEX_MAINTENANCE: i18n.t(
+        'Tracker trigram index maintenance'
+    ),
     VALIDATION_RESULTS_NOTIFICATION: i18n.t('Validation results notification'),
 }
 

--- a/src/services/server-translations/jobTypesMap.js
+++ b/src/services/server-translations/jobTypesMap.js
@@ -52,6 +52,7 @@ const jobTypesMap = {
     TRACKER_IMPORT_RULE_ENGINE_JOB: i18n.t('Tracker import rule engine job'),
     TRACKER_PROGRAMS_DATA_SYNC: i18n.t('Tracker programs data sync'),
     TRACKER_SEARCH_OPTIMIZATION: i18n.t('Tracker search optimization'),
+    TRACKER_TRIGRAM_INDEX_MAINTENANCE: i18n.t('Tracker search optimization'),
     VALIDATION_RESULTS_NOTIFICATION: i18n.t('Validation results notification'),
 }
 


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-12051

The backend PR changes the name of the job type from `TRACKER_SEARCH_OPTIMIZATION` to `TRACKER_TRIGRAM_INDEX_MAINTENANCE`. This means we need to add `TRACKER_TRIGRAM_INDEX_MAINTENANCE` into the list of know job types.

In order to be backwards compatible and non-feature toggled, it's easiest to just add the new name rather than to replace it.