### PR TITLE
fix: disable pushAnalysis in v43

### DIFF
--- a/cypress/e2e/add-job/create-parameter-jobs.feature
+++ b/cypress/e2e/add-job/create-parameter-jobs.feature
@@ -18,5 +18,5 @@ Feature: Users should be able to create jobs that take parameters
         |   event programs data sync |          cron |
         |              metadata sync |          cron |
         |                 monitoring |          cron |
-        |              push analysis |          cron |
+        # |              push analysis |          cron |
         |                  predictor |          cron |

--- a/cypress/e2e/edit-job/edit-parameter-jobs.feature
+++ b/cypress/e2e/edit-job/edit-parameter-jobs.feature
@@ -19,5 +19,5 @@ Feature: Users should be able to edit jobs that take parameters
         |   event programs data sync |          cron |
         |              metadata sync |          cron |
         |                 monitoring |          cron |
-        |              push analysis |          cron |
+        # |              push analysis |          cron |
         |                  predictor |          cron |

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -4,6 +4,7 @@ import { Routes } from '../Routes'
 import { AuthWall } from '../AuthWall'
 import { Store } from '../Store'
 import { PageWrapper } from '../PageWrapper'
+import { FeatureToggleProvider } from '../../hooks/featureToggle'
 import './App.css'
 
 /* eslint-disable-next-line import/no-unassigned-import -- Necessary for translations to work */
@@ -12,13 +13,15 @@ import '../../locales'
 const App = () => (
     <React.Fragment>
         <CssVariables spacers colors theme />
-        <PageWrapper>
-            <AuthWall>
-                <Store>
-                    <Routes />
-                </Store>
-            </AuthWall>
-        </PageWrapper>
+        <FeatureToggleProvider>
+            <PageWrapper>
+                <AuthWall>
+                    <Store>
+                        <Routes />
+                    </Store>
+                </AuthWall>
+            </PageWrapper>
+        </FeatureToggleProvider>
     </React.Fragment>
 )
 

--- a/src/hooks/featureToggle/feature-toggle-context.jsx
+++ b/src/hooks/featureToggle/feature-toggle-context.jsx
@@ -1,0 +1,7 @@
+import { createContext } from 'react'
+
+const FeatureToggleContext = createContext({
+    showPushAnalysis: false,
+})
+
+export { FeatureToggleContext }

--- a/src/hooks/featureToggle/feature-toggle-provider.jsx
+++ b/src/hooks/featureToggle/feature-toggle-provider.jsx
@@ -1,0 +1,24 @@
+import { useConfig } from '@dhis2/app-runtime'
+import { PropTypes } from '@dhis2/prop-types'
+import React from 'react'
+import { FeatureToggleContext } from './feature-toggle-context'
+
+const FeatureToggleProvider = ({ children }) => {
+    const { serverVersion } = useConfig()
+
+    const providerValue = {
+        showPushAnalysis: serverVersion?.minor <= 42,
+    }
+
+    return (
+        <FeatureToggleContext.Provider value={providerValue}>
+            {children}
+        </FeatureToggleContext.Provider>
+    )
+}
+
+FeatureToggleProvider.propTypes = {
+    children: PropTypes.node.isRequired,
+}
+
+export { FeatureToggleProvider }

--- a/src/hooks/featureToggle/index.js
+++ b/src/hooks/featureToggle/index.js
@@ -1,0 +1,2 @@
+export { useFeatureToggle } from './use-feature-toggle'
+export { FeatureToggleProvider } from './feature-toggle-provider'

--- a/src/hooks/featureToggle/use-feature-toggle.js
+++ b/src/hooks/featureToggle/use-feature-toggle.js
@@ -1,0 +1,4 @@
+import { useContext } from 'react'
+import { FeatureToggleContext } from './feature-toggle-context'
+
+export const useFeatureToggle = () => useContext(FeatureToggleContext)

--- a/src/hooks/parameter-options/use-parameter-option.test.jsx
+++ b/src/hooks/parameter-options/use-parameter-option.test.jsx
@@ -12,7 +12,7 @@ describe('useParameterOption', () => {
             validationRuleGroups: {
                 validationRuleGroups: expected,
             },
-            pushAnalysis: { pushAnalysis: 'pushAnalysis' },
+            // pushAnalysis: { pushAnalysis: 'pushAnalysis' },
             predictors: { predictors: 'predictors' },
             predictorGroups: { predictorGroups: 'predictorGroups' },
             dataIntegrity: 'dataIntegrityChecks',

--- a/src/hooks/parameter-options/use-parameter-options.js
+++ b/src/hooks/parameter-options/use-parameter-options.js
@@ -1,4 +1,5 @@
 import { useDataQuery } from '@dhis2/app-runtime'
+import { useFeatureToggle } from '../featureToggle'
 
 const query = {
     skipTableTypes: {
@@ -6,12 +7,6 @@ const query = {
     },
     validationRuleGroups: {
         resource: 'validationRuleGroups',
-        params: {
-            paging: false,
-        },
-    },
-    pushAnalysis: {
-        resource: 'pushAnalysis',
         params: {
             paging: false,
         },
@@ -42,8 +37,19 @@ const query = {
     },
 }
 
+const queryWithPushAnalysis = {
+    ...query,
+    pushAnalysis: {
+        resource: 'pushAnalysis',
+        params: {
+            paging: false,
+        },
+    },
+}
+
 const useParameterOptions = () => {
-    const fetch = useDataQuery(query)
+    const { showPushAnalysis } = useFeatureToggle()
+    const fetch = useDataQuery(showPushAnalysis ? queryWithPushAnalysis : query)
 
     // Remove nesting from data
     if (fetch.data) {
@@ -61,13 +67,13 @@ const useParameterOptions = () => {
         if (
             !skipTableTypes ||
             !validationRuleGroups ||
-            !pushAnalysis ||
             !predictors ||
             !predictorGroups ||
             !dataIntegrityChecks ||
             !dashboard ||
             !receivers ||
-            !skipPrograms
+            !skipPrograms ||
+            (showPushAnalysis ? !pushAnalysis : false)
         ) {
             const error = new Error(
                 'Did not receive the expected parameter options'
@@ -78,13 +84,16 @@ const useParameterOptions = () => {
         const data = {
             skipTableTypes,
             validationRuleGroups,
-            pushAnalysis,
             predictors,
             predictorGroups,
             dataIntegrityChecks,
             dashboard,
             receivers,
             skipPrograms,
+        }
+
+        if (showPushAnalysis) {
+            data.pushAnalysis = pushAnalysis
         }
 
         return { ...fetch, data }

--- a/src/hooks/parameter-options/use-parameter-options.test.jsx
+++ b/src/hooks/parameter-options/use-parameter-options.test.jsx
@@ -10,7 +10,7 @@ describe('useParameterOptions', () => {
             validationRuleGroups: {
                 validationRuleGroups: 'validationRuleGroups',
             },
-            pushAnalysis: { pushAnalysis: 'pushAnalysis' },
+            // pushAnalysis: { pushAnalysis: 'pushAnalysis' },
             predictors: { predictors: 'predictors' },
             predictorGroups: { predictorGroups: 'predictorGroups' },
             dataIntegrity: 'dataIntegrityChecks',
@@ -33,7 +33,7 @@ describe('useParameterOptions', () => {
                 data: {
                     skipTableTypes: 'skipTableTypes',
                     validationRuleGroups: 'validationRuleGroups',
-                    pushAnalysis: 'pushAnalysis',
+                    // pushAnalysis: 'pushAnalysis',
                     predictors: 'predictors',
                     predictorGroups: 'predictorGroups',
                     dataIntegrityChecks: 'dataIntegrityChecks',
@@ -49,7 +49,7 @@ describe('useParameterOptions', () => {
         const data = {
             'analytics/tableTypes': 'skipTableTypes',
             validationRuleGroups: {},
-            pushAnalysis: { pushAnalysis: 'pushAnalysis' },
+            // pushAnalysis: { pushAnalysis: 'pushAnalysis' },
             predictors: { predictors: 'predictors' },
             predictorGroups: { predictorGroups: 'predictorGroups' },
             dataIntegrity: 'dataIntegrityChecks',


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-21301. This PR feature toggles the request/display of push analysis job types.

- Adds a feature toggle provider/hook to centralise feature toggle logic (I thought this would be easier in the long run). In some apps, we've done it this way; in others, we have more one-off logic.
- Updates logic in useParameterOptions hook to toggle pushAnalysis on/off (based on the version logic which is in the feature toggle provider). [Note: this hook seems to be pretty inefficient and is rerunning when you change job types, but I don't think it's worth it/within scope of this bug to refactor]
- Comments out references to push analysis in tests [ideally the tests should be rewritten to test the feature toggle functionality (at least the unit tests), but I don't know if we want to spend time reworking the tests now or just push a fix sooner]